### PR TITLE
feat(review) : add Review Creation, Update, and Deletion functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,7 @@ out/
 ### VS Code ###
 .vscode/
 
-application-dev.yml
+application-prod.yml
+application-test.yml
+.env
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 //    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/linked/classbridge/config/S3Config.java
+++ b/src/main/java/com/linked/classbridge/config/S3Config.java
@@ -1,0 +1,31 @@
+package com.linked.classbridge.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${AWS_ACCESS_KEY}")
+    private String accessKey;
+
+    @Value("${AWS_SECRET_KEY}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client s3Client() {
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(
+                        new BasicAWSCredentials(accessKey, secretKey)))
+                .build();
+    }
+}

--- a/src/main/java/com/linked/classbridge/controller/ReviewController.java
+++ b/src/main/java/com/linked/classbridge/controller/ReviewController.java
@@ -3,6 +3,7 @@ package com.linked.classbridge.controller;
 import com.linked.classbridge.domain.User;
 import com.linked.classbridge.dto.SuccessResponse;
 import com.linked.classbridge.dto.review.RegisterReviewDto;
+import com.linked.classbridge.dto.review.UpdateReviewDto;
 import com.linked.classbridge.repository.UserRepository;
 import com.linked.classbridge.service.ReviewService;
 import com.linked.classbridge.type.ResponseMessage;
@@ -12,7 +13,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
@@ -33,6 +36,21 @@ public class ReviewController {
                 SuccessResponse.of(
                         ResponseMessage.REVIEW_REGISTER_SUCCESS,
                         reviewService.registerReview(user, request)
+                )
+        );
+    }
+
+    @PutMapping("/{reviewId}")
+    public ResponseEntity<SuccessResponse<?>> updateReview(
+            @Valid @ModelAttribute UpdateReviewDto.Request request,
+            @PathVariable Long reviewId
+    ) {
+        User user = userRepository.findById(1L).orElse(null);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                SuccessResponse.of(
+                        ResponseMessage.REVIEW_UPDATE_SUCCESS,
+                        reviewService.updateReview(user, request, reviewId)
                 )
         );
     }

--- a/src/main/java/com/linked/classbridge/controller/ReviewController.java
+++ b/src/main/java/com/linked/classbridge/controller/ReviewController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -51,6 +52,20 @@ public class ReviewController {
                 SuccessResponse.of(
                         ResponseMessage.REVIEW_UPDATE_SUCCESS,
                         reviewService.updateReview(user, request, reviewId)
+                )
+        );
+    }
+
+    @DeleteMapping("/{reviewId}")
+    public ResponseEntity<SuccessResponse<?>> deleteReview(
+            @PathVariable Long reviewId
+    ) {
+        User user = userRepository.findById(1L).orElse(null);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                SuccessResponse.of(
+                        ResponseMessage.REVIEW_DELETE_SUCCESS,
+                        reviewService.deleteReview(user, reviewId)
                 )
         );
     }

--- a/src/main/java/com/linked/classbridge/controller/ReviewController.java
+++ b/src/main/java/com/linked/classbridge/controller/ReviewController.java
@@ -1,0 +1,39 @@
+package com.linked.classbridge.controller;
+
+import com.linked.classbridge.domain.User;
+import com.linked.classbridge.dto.SuccessResponse;
+import com.linked.classbridge.dto.review.RegisterReviewDto;
+import com.linked.classbridge.repository.UserRepository;
+import com.linked.classbridge.service.ReviewService;
+import com.linked.classbridge.type.ResponseMessage;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/reviews")
+public class ReviewController {
+
+    private final UserRepository userRepository;
+    private final ReviewService reviewService;
+
+    @PostMapping
+    public ResponseEntity<SuccessResponse<?>> registerReview(
+            @Valid @ModelAttribute RegisterReviewDto.Request request
+    ) {
+        User user = userRepository.findById(1L).orElse(null);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+                SuccessResponse.of(
+                        ResponseMessage.REVIEW_REGISTER_SUCCESS,
+                        reviewService.registerReview(user, request)
+                )
+        );
+    }
+}

--- a/src/main/java/com/linked/classbridge/dataloader/InitDataLoader.java
+++ b/src/main/java/com/linked/classbridge/dataloader/InitDataLoader.java
@@ -33,6 +33,8 @@ public class InitDataLoader implements CommandLineRunner {
         OneDayClass saveOneDayClass = oneDayClassRepository.findById(1L)
                 .orElseGet(() -> oneDayClassRepository.save(OneDayClass.builder()
                         .tutor(savedUser)
+                        .totalReviews(0)
+                        .totalStarRate(0D)
                         .build()));
 
         Lesson savedLesson = lessonRepository.findById(1L)

--- a/src/main/java/com/linked/classbridge/dataloader/InitDataLoader.java
+++ b/src/main/java/com/linked/classbridge/dataloader/InitDataLoader.java
@@ -1,0 +1,43 @@
+package com.linked.classbridge.dataloader;
+
+import com.linked.classbridge.domain.Lesson;
+import com.linked.classbridge.domain.OneDayClass;
+import com.linked.classbridge.domain.User;
+import com.linked.classbridge.repository.LessonRepository;
+import com.linked.classbridge.repository.OneDayClassRepository;
+import com.linked.classbridge.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class InitDataLoader implements CommandLineRunner {
+
+    private final UserRepository userRepository;
+
+    private final OneDayClassRepository oneDayClassRepository;
+
+    private final LessonRepository lessonRepository;
+
+
+    @Override
+    public void run(String... args) throws Exception {
+        User savedUser = userRepository.findById(1L)
+                .orElseGet(() -> userRepository.save(User.builder()
+                        .email("admin@mail.com")
+                        .password("admin")
+                        .nickname("admin")
+                        .build()));
+
+        OneDayClass saveOneDayClass = oneDayClassRepository.findById(1L)
+                .orElseGet(() -> oneDayClassRepository.save(OneDayClass.builder()
+                        .tutor(savedUser)
+                        .build()));
+
+        Lesson savedLesson = lessonRepository.findById(1L)
+                .orElseGet(() -> lessonRepository.save(Lesson.builder()
+                        .oneDayClass(saveOneDayClass)
+                        .build()));
+    }
+}

--- a/src/main/java/com/linked/classbridge/domain/Lesson.java
+++ b/src/main/java/com/linked/classbridge/domain/Lesson.java
@@ -1,0 +1,42 @@
+package com.linked.classbridge.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Inheritance(strategy = InheritanceType.JOINED)
+@SQLDelete(sql = "UPDATE lesson SET deleted_at = now() WHERE lesson_id = ?")
+@SQLRestriction("deleted_at is null")
+public class Lesson extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long lessonId;
+
+    @ManyToOne
+    @JoinColumn(name = "one_day_class_id")
+    private OneDayClass oneDayClass;
+
+    @OneToMany(mappedBy = "lesson", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<Review> reviewList;
+}

--- a/src/main/java/com/linked/classbridge/domain/OneDayClass.java
+++ b/src/main/java/com/linked/classbridge/domain/OneDayClass.java
@@ -37,6 +37,27 @@ public class OneDayClass extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User tutor;
 
+    private Double totalStarRate;
+
+    private Integer totalReviews;
+
+
     @OneToMany(mappedBy = "oneDayClass", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Review> reviewList;
+
+    public void addReview(Review review) {
+        this.reviewList.add(review);
+        this.totalStarRate += review.getRating();
+        this.totalReviews++;
+    }
+
+    public void removeReview(Review review) {
+        this.reviewList.remove(review);
+        this.totalStarRate -= review.getRating();
+        this.totalReviews--;
+    }
+
+    public void updateTotalStarRate(Double diff) {
+        this.totalStarRate += diff;
+    }
 }

--- a/src/main/java/com/linked/classbridge/domain/OneDayClass.java
+++ b/src/main/java/com/linked/classbridge/domain/OneDayClass.java
@@ -1,0 +1,42 @@
+package com.linked.classbridge.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Inheritance(strategy = InheritanceType.JOINED)
+@SQLDelete(sql = "UPDATE one_day_class SET deleted_at = now() WHERE one_day_class_id = ?")
+@SQLRestriction("deleted_at is null")
+public class OneDayClass extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long oneDayClassId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User tutor;
+
+    @OneToMany(mappedBy = "oneDayClass", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<Review> reviewList;
+}

--- a/src/main/java/com/linked/classbridge/domain/Review.java
+++ b/src/main/java/com/linked/classbridge/domain/Review.java
@@ -1,0 +1,57 @@
+package com.linked.classbridge.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Inheritance(strategy = InheritanceType.JOINED)
+@SQLDelete(sql = "UPDATE review SET deleted_at = now() WHERE review_id = ?")
+@SQLRestriction("deleted_at is null")
+public class Review extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long reviewId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lesson_id")
+    private Lesson lesson;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "one_day_class_id")
+    private OneDayClass oneDayClass;
+
+    @Column(nullable = false)
+    private String contents;
+
+    @Column(nullable = false)
+    private double rating;
+
+    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL)
+    private List<ReviewImage> reviewImageList;
+}

--- a/src/main/java/com/linked/classbridge/domain/Review.java
+++ b/src/main/java/com/linked/classbridge/domain/Review.java
@@ -54,4 +54,9 @@ public class Review extends BaseEntity {
 
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL)
     private List<ReviewImage> reviewImageList;
+
+    public void update(String contents, Double rating) {
+        this.contents = contents;
+        this.rating = rating;
+    }
 }

--- a/src/main/java/com/linked/classbridge/domain/ReviewImage.java
+++ b/src/main/java/com/linked/classbridge/domain/ReviewImage.java
@@ -33,4 +33,8 @@ public class ReviewImage {
 
     @Column(nullable = false)
     private String url;
+
+    public void updateUrl(String url) {
+        this.url = url;
+    }
 }

--- a/src/main/java/com/linked/classbridge/domain/ReviewImage.java
+++ b/src/main/java/com/linked/classbridge/domain/ReviewImage.java
@@ -1,0 +1,36 @@
+package com.linked.classbridge.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReviewImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long reviewImageId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id")
+    private Review review;
+
+    @Column(nullable = false)
+    private Integer sequence;
+
+    @Column(nullable = false)
+    private String url;
+}

--- a/src/main/java/com/linked/classbridge/domain/User.java
+++ b/src/main/java/com/linked/classbridge/domain/User.java
@@ -26,7 +26,7 @@ import org.hibernate.annotations.SQLRestriction;
 @AllArgsConstructor
 @SuperBuilder
 @Inheritance(strategy = InheritanceType.JOINED)
-@SQLDelete(sql = "UPDATE user SET deleted_at = NOW() WHERE id = ?")
+@SQLDelete(sql = "UPDATE user SET deleted_at = NOW() WHERE user_id = ?")
 @SQLRestriction("deleted_at is null")
 public class User extends BaseEntity {
 

--- a/src/main/java/com/linked/classbridge/domain/User.java
+++ b/src/main/java/com/linked/classbridge/domain/User.java
@@ -1,0 +1,47 @@
+package com.linked.classbridge.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity(name = "user")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Inheritance(strategy = InheritanceType.JOINED)
+@SQLDelete(sql = "UPDATE user SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at is null")
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    private String password;
+
+    @Column(unique = true, nullable = false)
+    private String nickname;
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<Review> reviewList;
+}

--- a/src/main/java/com/linked/classbridge/dto/review/DeleteReviewResponse.java
+++ b/src/main/java/com/linked/classbridge/dto/review/DeleteReviewResponse.java
@@ -1,0 +1,6 @@
+package com.linked.classbridge.dto.review;
+
+public record DeleteReviewResponse(
+        Long reviewId
+) {
+}

--- a/src/main/java/com/linked/classbridge/dto/review/RegisterReviewDto.java
+++ b/src/main/java/com/linked/classbridge/dto/review/RegisterReviewDto.java
@@ -1,0 +1,60 @@
+package com.linked.classbridge.dto.review;
+
+import com.linked.classbridge.domain.Lesson;
+import com.linked.classbridge.domain.OneDayClass;
+import com.linked.classbridge.domain.Review;
+import com.linked.classbridge.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.springframework.web.multipart.MultipartFile;
+
+public class RegisterReviewDto {
+
+    public record Request(
+            @Schema(description = "클래스 ID", example = "1")
+            @NotNull(message = "클래스 ID를 입력해 주세요.")
+            Long classId,
+
+            @Schema(description = "레슨 ID", example = "1")
+            @NotNull(message = "레슨 ID를 입력해 주세요.")
+            Long lessonId,
+
+            @Schema(description = "리뷰 내용", example = "유익한 수업이었습니다.")
+            @NotBlank(message = "리뷰 내용을 입력해 주세요.")
+            @Size(min = 10, max = 200, message = "리뷰 내용은 10자 이상 200자 이하로 입력해 주세요.")
+            String contents,
+
+            @Schema(description = "평점", example = "4.5", minimum = "0", maximum = "5")
+            @Min(value = 0, message = "평점은 0 이상 5 이하로 입력해 주세요.")
+            @Max(value = 5, message = "평점은 0 이상 5 이하로 입력해 주세요.")
+            @NotNull(message = "평점을 입력해 주세요.")
+            Double rating,
+            MultipartFile image1,
+            MultipartFile image2,
+            MultipartFile image3
+    ) {
+
+        public static Review toEntity(
+                User user, Lesson lesson, OneDayClass oneDayClass, Request request
+        ) {
+            return Review.builder()
+                    .user(user)
+                    .lesson(lesson)
+                    .oneDayClass(oneDayClass)
+                    .contents(request.contents())
+                    .rating(request.rating())
+                    .build();
+        }
+    }
+
+    public record Response(Long reviewId) {
+        public static Response fromEntity(Review review) {
+            return new Response(review.getReviewId());
+        }
+    }
+
+}

--- a/src/main/java/com/linked/classbridge/dto/review/UpdateReviewDto.java
+++ b/src/main/java/com/linked/classbridge/dto/review/UpdateReviewDto.java
@@ -1,0 +1,60 @@
+package com.linked.classbridge.dto.review;
+
+import com.linked.classbridge.domain.Lesson;
+import com.linked.classbridge.domain.OneDayClass;
+import com.linked.classbridge.domain.Review;
+import com.linked.classbridge.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.springframework.web.multipart.MultipartFile;
+
+public class UpdateReviewDto {
+
+    public record Request(
+            @Schema(description = "리뷰 내용", example = "유익한 수업이었습니다.")
+            @NotBlank(message = "리뷰 내용을 입력해 주세요.")
+            @Size(min = 10, max = 200, message = "리뷰 내용은 10자 이상 200자 이하로 입력해 주세요.")
+            String contents,
+
+            @Schema(description = "평점", example = "4.5", minimum = "0", maximum = "5")
+            @Min(value = 0, message = "평점은 0 이상 5 이하로 입력해 주세요.")
+            @Max(value = 5, message = "평점은 0 이상 5 이하로 입력해 주세요.")
+            @NotNull(message = "평점을 입력해 주세요.")
+            Double rating,
+            MultipartFile image1,
+            MultipartFile image2,
+            MultipartFile image3
+    ) {
+
+        public static Review toEntity(
+                User user, Lesson lesson, OneDayClass oneDayClass, RegisterReviewDto.Request request
+        ) {
+            return Review.builder()
+                    .user(user)
+                    .lesson(lesson)
+                    .oneDayClass(oneDayClass)
+                    .contents(request.contents())
+                    .rating(request.rating())
+                    .build();
+        }
+    }
+
+    public record Response(
+            Long reviewId,
+            String contents,
+            Double rating
+
+    ) {
+        public static UpdateReviewDto.Response fromEntity(Review review) {
+            return new UpdateReviewDto.Response(
+                    review.getReviewId(),
+                    review.getContents(),
+                    review.getRating()
+            );
+        }
+    }
+}

--- a/src/main/java/com/linked/classbridge/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/linked/classbridge/exception/GlobalExceptionHandler.java
@@ -69,7 +69,7 @@ public class GlobalExceptionHandler {
         log.error("DataIntegrityViolationException occurred", e);
         return handleExceptionInternal(BAD_REQUEST);
     }
-    
+
     /**
      * Exception 처리
      *
@@ -86,12 +86,19 @@ public class GlobalExceptionHandler {
 
     private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode) {
         return ResponseEntity.status(errorCode.getHttpStatus())
-                .body(errorCode.getDescription());
+                .body(makeErrorResponseBody(errorCode));
     }
 
     private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorCode errorCode) {
         return ResponseEntity.status(errorCode.getHttpStatus())
                 .body(makeErrorResponseBody((MethodArgumentNotValidException) e, errorCode));
+    }
+
+    private ErrorResponse makeErrorResponseBody(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .code(errorCode.name())
+                .message(errorCode.getDescription())
+                .build();
     }
 
     private ErrorResponse makeErrorResponseBody(BindException e, ErrorCode errorCode) {

--- a/src/main/java/com/linked/classbridge/repository/LessonRepository.java
+++ b/src/main/java/com/linked/classbridge/repository/LessonRepository.java
@@ -1,0 +1,9 @@
+package com.linked.classbridge.repository;
+
+import com.linked.classbridge.domain.Lesson;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LessonRepository extends JpaRepository<Lesson, Long> {
+}

--- a/src/main/java/com/linked/classbridge/repository/OneDayClassRepository.java
+++ b/src/main/java/com/linked/classbridge/repository/OneDayClassRepository.java
@@ -1,0 +1,9 @@
+package com.linked.classbridge.repository;
+
+import com.linked.classbridge.domain.OneDayClass;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OneDayClassRepository extends JpaRepository<OneDayClass, Long> {
+}

--- a/src/main/java/com/linked/classbridge/repository/ReviewImageRepository.java
+++ b/src/main/java/com/linked/classbridge/repository/ReviewImageRepository.java
@@ -1,9 +1,12 @@
 package com.linked.classbridge.repository;
 
+import com.linked.classbridge.domain.Review;
 import com.linked.classbridge.domain.ReviewImage;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
+    List<ReviewImage> findByReviewOrderBySequenceAsc(Review review);
 }

--- a/src/main/java/com/linked/classbridge/repository/ReviewImageRepository.java
+++ b/src/main/java/com/linked/classbridge/repository/ReviewImageRepository.java
@@ -1,0 +1,9 @@
+package com.linked.classbridge.repository;
+
+import com.linked.classbridge.domain.ReviewImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
+}

--- a/src/main/java/com/linked/classbridge/repository/ReviewRepository.java
+++ b/src/main/java/com/linked/classbridge/repository/ReviewRepository.java
@@ -1,0 +1,13 @@
+package com.linked.classbridge.repository;
+
+import com.linked.classbridge.domain.Lesson;
+import com.linked.classbridge.domain.Review;
+import com.linked.classbridge.domain.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+    Optional<Review> findByLessonAndUser(Lesson lesson, User user);
+}

--- a/src/main/java/com/linked/classbridge/repository/UserRepository.java
+++ b/src/main/java/com/linked/classbridge/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.linked.classbridge.repository;
+
+import com.linked.classbridge.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/linked/classbridge/service/LessonService.java
+++ b/src/main/java/com/linked/classbridge/service/LessonService.java
@@ -1,0 +1,22 @@
+package com.linked.classbridge.service;
+
+import com.linked.classbridge.domain.Lesson;
+import com.linked.classbridge.exception.RestApiException;
+import com.linked.classbridge.repository.LessonRepository;
+import com.linked.classbridge.type.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LessonService {
+
+    private final LessonRepository lessonRepository;
+
+    public Lesson findLessonById(Long lessonId) {
+        return lessonRepository.findById(lessonId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.LESSON_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/linked/classbridge/service/ReviewService.java
+++ b/src/main/java/com/linked/classbridge/service/ReviewService.java
@@ -1,0 +1,94 @@
+package com.linked.classbridge.service;
+
+import com.linked.classbridge.domain.Lesson;
+import com.linked.classbridge.domain.OneDayClass;
+import com.linked.classbridge.domain.Review;
+import com.linked.classbridge.domain.ReviewImage;
+import com.linked.classbridge.domain.User;
+import com.linked.classbridge.dto.review.RegisterReviewDto;
+import com.linked.classbridge.dto.review.RegisterReviewDto.Request;
+import com.linked.classbridge.exception.RestApiException;
+import com.linked.classbridge.repository.ReviewImageRepository;
+import com.linked.classbridge.repository.ReviewRepository;
+import com.linked.classbridge.type.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+
+    private final ReviewImageRepository reviewImageRepository;
+
+    private final LessonService lessonService;
+
+    private final S3Service s3Service;
+
+    /**
+     * 리뷰 등록
+     *
+     * @param request 리뷰 등록 요청
+     * @return 리뷰 등록 응답
+     */
+    @Transactional
+    public RegisterReviewDto.Response registerReview(User user, RegisterReviewDto.Request request) {
+        System.out.println("request = " + request);
+        validateReview(request);
+
+        Lesson lesson = lessonService.findLessonById(request.lessonId());
+        OneDayClass oneDayClass = lesson.getOneDayClass();
+
+        // 클래스 ID가 일치하는지 확인
+        if (ObjectUtils.notEqual(request.classId(), oneDayClass.getOneDayClassId())) {
+            throw new RestApiException(ErrorCode.INVALID_ONE_DAY_CLASS_ID);
+        }
+
+        // 리뷰를 이미 작성했는지 확인 (하나의 레슨에 대해 유저는 하나의 리뷰만 작성 가능)
+        reviewRepository.findByLessonAndUser(lesson, user).ifPresent(review -> {
+            throw new RestApiException(ErrorCode.REVIEW_ALREADY_EXISTS);
+        });
+
+        // 리뷰 등록
+        Review savedReview =
+                reviewRepository.save(Request.toEntity(user, lesson, oneDayClass, request));
+
+        // 리뷰 이미지 등록
+        uploadAndSaveReviewImage(savedReview, request.image1(), request.image2(), request.image3());
+
+        return RegisterReviewDto.Response.fromEntity(savedReview);
+    }
+
+    public void validateReview(Request request) {
+        if (request.rating() < 0 || request.rating() > 5) {
+            throw new RestApiException(ErrorCode.INVALID_REVIEW_RATING);
+        }
+        if (request.contents().length() < 10 || request.contents().length() > 200) {
+            throw new RestApiException(ErrorCode.INVALID_REVIEW_CONTENTS);
+        }
+    }
+
+    private void uploadAndSaveReviewImage(Review savedReview, MultipartFile... images) {
+        // 리뷰 이미지 등록
+        int sequence = 1;
+        for (MultipartFile image : images) {
+            if (image != null && !image.isEmpty()) {
+                // 이미지 S3 저장
+                String url = s3Service.uploadReviewImage(image);
+                // 리뷰 이미지 저장
+                reviewImageRepository.save(ReviewImage.builder()
+                        .review(savedReview)
+                        .url(url)
+                        .sequence(sequence++)
+                        .build());
+
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/linked/classbridge/service/S3Service.java
+++ b/src/main/java/com/linked/classbridge/service/S3Service.java
@@ -1,0 +1,102 @@
+package com.linked.classbridge.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.linked.classbridge.exception.RestApiException;
+import com.linked.classbridge.type.ErrorCode;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class S3Service {
+
+    private final AmazonS3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private static final String[] IMAGE_EXTENSIONS =
+            {"jpg", "jpeg", "png", "gif", "bmp", "svg", "webp"};
+
+    private static final String REVIEW_FOLDER = "review/";
+
+    private static final String USER_PROFILE_FOLDER = "userProfile/";
+
+    private static final String ONE_DAY_CLASS_FOLDER = "oneDayClass/";
+
+    @Transactional
+    public String uploadReviewImage(MultipartFile image) {
+        return uploadImage(image, REVIEW_FOLDER);
+    }
+
+    /**
+     * S3에 파일 업로드
+     *
+     * @param file   파일
+     * @param folder 폴더
+     * @return 업로드된 파일 URL
+     */
+    @Transactional
+    public String uploadImage(MultipartFile file, String folder) {
+        String fileName = folder + UUID.randomUUID() + file.getOriginalFilename();
+
+        validateImageFile(file);
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        metadata.setContentType(file.getContentType());
+
+        try {
+            s3Client.putObject(
+                    new PutObjectRequest(bucket, fileName, file.getInputStream(), metadata)
+                            .withCannedAcl(CannedAccessControlList.PublicRead)
+            );
+            return s3Client.getUrl(bucket, fileName).toString();
+        } catch (Exception e) {
+            log.error("Failed to upload image", e);
+            throw new RestApiException(ErrorCode.FAILED_TO_UPLOAD_IMAGE);
+        }
+    }
+
+    /**
+     * S3에 저장된 이미지 삭제
+     *
+     * @param url 이미지 URL
+     */
+    @Transactional
+    public void delete(String url) {
+        try {
+            s3Client.deleteObject(bucket, getFileNameFromURL(url));
+        } catch (Exception e) {
+            log.error("Failed to delete image", e);
+            throw new RestApiException(ErrorCode.FAILED_TO_DELETE_IMAGE);
+        }
+    }
+
+    public String getFileNameFromURL(String url) {
+        return url.substring(url.indexOf("com/") + 4);
+    }
+
+    private void validateImageFile(MultipartFile file) {
+        String extension = Objects.requireNonNull(file.getOriginalFilename())
+                .substring(file.getOriginalFilename().lastIndexOf(".") + 1)
+                .toLowerCase();
+        for (String imageExtension : IMAGE_EXTENSIONS) {
+            if (extension.equals(imageExtension)) {
+                return;
+            }
+        }
+        throw new RestApiException(ErrorCode.INVALID_IMAGE_FILE_EXTENSION);
+    }
+}

--- a/src/main/java/com/linked/classbridge/type/ErrorCode.java
+++ b/src/main/java/com/linked/classbridge/type/ErrorCode.java
@@ -25,6 +25,8 @@ public enum ErrorCode {
     FAILED_TO_DELETE_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 삭제에 실패했습니다."),
 
     LESSON_NOT_FOUND(HttpStatus.BAD_REQUEST, "클래스를 찾을 수 없습니다."),
+    REVIEW_NOT_FOUND(HttpStatus.BAD_REQUEST, "리뷰를 찾을 수 없습니다."),
+    NOT_REVIEW_OWNER(HttpStatus.FORBIDDEN, "리뷰 작성자만 수정 및 삭제가 가능합니다."),
     ;
     private final HttpStatus httpStatus;
     private final String description;

--- a/src/main/java/com/linked/classbridge/type/ErrorCode.java
+++ b/src/main/java/com/linked/classbridge/type/ErrorCode.java
@@ -16,6 +16,15 @@ public enum ErrorCode {
     HELLO_NAME_IS_REQUIRED(HttpStatus.BAD_REQUEST, "Hello 이름은 필수입니다."),
     HELLO_NOT_FOUND(HttpStatus.BAD_REQUEST, "Hello를 찾을 수 없습니다."),
 
+    REVIEW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 리뷰를 작성하셨습니다."),
+    INVALID_ONE_DAY_CLASS_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 클래스 ID 입니다."),
+    INVALID_REVIEW_RATING(HttpStatus.BAD_REQUEST, "리뷰 평점은 1점부터 5점까지 가능합니다."),
+    INVALID_REVIEW_CONTENTS(HttpStatus.BAD_REQUEST, "리뷰 내용은 10자 이상 200자 이하로 작성해주세요."),
+    INVALID_IMAGE_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "유효한 이미지 파일이 아닙니다."),
+    FAILED_TO_UPLOAD_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다."),
+    FAILED_TO_DELETE_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 삭제에 실패했습니다."),
+
+    LESSON_NOT_FOUND(HttpStatus.BAD_REQUEST, "클래스를 찾을 수 없습니다."),
     ;
     private final HttpStatus httpStatus;
     private final String description;

--- a/src/main/java/com/linked/classbridge/type/ResponseMessage.java
+++ b/src/main/java/com/linked/classbridge/type/ResponseMessage.java
@@ -9,7 +9,10 @@ public enum ResponseMessage {
     HELLO_GET_SUCCESS("Hello 조회 성공"),
     HELLO_REGISTER_SUCCESS("Hello 등록 성공"),
     HELLO_UPDATE_SUCCESS("Hello 수정 성공"),
-    REVIEW_REGISTER_SUCCESS("리뷰 등록 성공");
+    REVIEW_REGISTER_SUCCESS("리뷰 등록 성공"),
+    REVIEW_UPDATE_SUCCESS("리뷰 수정 성공"),
+    REVIEW_DELETE_SUCCESS("리뷰 삭제 성공"),
+    ;
 
     private final String message;
 }

--- a/src/main/java/com/linked/classbridge/type/ResponseMessage.java
+++ b/src/main/java/com/linked/classbridge/type/ResponseMessage.java
@@ -9,7 +9,7 @@ public enum ResponseMessage {
     HELLO_GET_SUCCESS("Hello 조회 성공"),
     HELLO_REGISTER_SUCCESS("Hello 등록 성공"),
     HELLO_UPDATE_SUCCESS("Hello 수정 성공"),
-    ;
+    REVIEW_REGISTER_SUCCESS("리뷰 등록 성공");
 
     private final String message;
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,11 +2,15 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/classBridge?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
     driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+
 
   jpa:
     defer-datasource-initialization: true
     hibernate:
       ddl-auto: update
+    open-in-view: false
     properties:
       hibernate:
         show-sql: true
@@ -14,3 +18,19 @@ spring:
         use_sql_comments: true
         jdbc:
           time_zone: UTC
+
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 5MB
+      max-request-size: 100MB
+
+cloud:
+  aws:
+    s3:
+      bucket: class-bridge
+    region:
+      static: ap-northeast-2
+      auto: false
+    stack:
+      auto: false

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,8 +2,6 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/classBridge?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
     driver-class-name: com.mysql.cj.jdbc.Driver
-    username: ${DB_USER}
-    password: ${DB_PASSWORD}
 
 
   jpa:
@@ -28,9 +26,12 @@ spring:
 cloud:
   aws:
     s3:
-      bucket: class-bridge
+      bucket: ${AWS_S3_BUCKET}
     region:
       static: ap-northeast-2
       auto: false
     stack:
       auto: false
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}

--- a/src/test/java/com/linked/classbridge/controller/ReviewControllerTest.java
+++ b/src/test/java/com/linked/classbridge/controller/ReviewControllerTest.java
@@ -1,0 +1,344 @@
+package com.linked.classbridge.controller;
+
+import static com.linked.classbridge.type.ErrorCode.NOT_REVIEW_OWNER;
+import static com.linked.classbridge.type.ErrorCode.REVIEW_ALREADY_EXISTS;
+import static com.linked.classbridge.type.ErrorCode.REVIEW_NOT_FOUND;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.linked.classbridge.domain.User;
+import com.linked.classbridge.dto.review.DeleteReviewResponse;
+import com.linked.classbridge.dto.review.RegisterReviewDto;
+import com.linked.classbridge.dto.review.UpdateReviewDto;
+import com.linked.classbridge.exception.RestApiException;
+import com.linked.classbridge.repository.UserRepository;
+import com.linked.classbridge.service.ReviewService;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = "spring.config.location=classpath:application-test.yml")
+class ReviewControllerTest {
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private ReviewService reviewService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    MockMultipartFile image1;
+    MockMultipartFile image2;
+    MockMultipartFile image3;
+
+    @BeforeEach
+    void setUp() {
+        image1 = new MockMultipartFile("images", "image1.jpg", "image/jpeg", "image1".getBytes());
+        image2 = new MockMultipartFile("images", "image2.jpg", "image/jpeg", "image2".getBytes());
+        image3 = new MockMultipartFile("images", "image3.jpg", "image/jpeg", "image3".getBytes());
+
+    }
+
+    @Test
+    @DisplayName("리뷰 등록 성공")
+    void registerReview_success() throws Exception {
+        // Given
+        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
+        given(reviewService.registerReview(any(User.class), any(RegisterReviewDto.Request.class)))
+                .willReturn(new RegisterReviewDto.Response(1L));
+
+        // When & Then
+        mockMvc.perform(multipart("/api/reviews")
+                        .file("image1", image1.getBytes())
+                        .file("image2", image2.getBytes())
+                        .file("image3", image3.getBytes())
+                        .param("lessonId", "1")
+                        .param("classId", "1")
+                        .param("contents", "This is a valid content.")
+                        .param("rating", "4.5")
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.reviewId").value(1L))
+        ;
+    }
+
+    @Test
+    @DisplayName("리뷰 등록 실패 - 레슨 ID 미입력")
+    void registerReview_fail_lessonId_not_enter() throws Exception {
+        // Given
+        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
+
+        // When & Then
+        mockMvc.perform(multipart("/api/reviews")
+                        .file("image1", image1.getBytes())
+                        .file("image2", image2.getBytes())
+                        .file("image3", image3.getBytes())
+                        .param("classId", "1")
+                        .param("contents", "This is a valid content.")
+                        .param("rating", "4.5")
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.errors[0].field").value("lessonId"))
+                .andExpect(jsonPath("$.errors[0].message").value("레슨 ID를 입력해 주세요."))
+        ;
+    }
+
+    @Test
+    @DisplayName("리뷰 등록 실패 - 리뷰 내용 길이 미달")
+    void registerReview_fail_contents_too_short() throws Exception {
+        // Given
+        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
+
+        // When & Then
+        mockMvc.perform(multipart("/api/reviews")
+                        .file("image1", image1.getBytes())
+                        .file("image2", image2.getBytes())
+                        .file("image3", image3.getBytes())
+                        .param("classId", "1")
+                        .param("lessonId", "1")
+                        .param("contents", "short") // 10자 미만
+                        .param("rating", "4.5")
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.errors[0].field").value("contents"))
+                .andExpect(jsonPath("$.errors[0].message").value("리뷰 내용은 10자 이상 200자 이하로 입력해 주세요."))
+        ;
+    }
+
+    @Test
+    @DisplayName("리뷰 등록 실패 - 평점 범위 초과")
+    void registerReview_fail_rating_out_of_range() throws Exception {
+        // Given
+        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
+
+        // When & Then
+        mockMvc.perform(multipart(HttpMethod.POST, "/api/reviews")
+                        .file("image1", image1.getBytes())
+                        .file("image2", image2.getBytes())
+                        .file("image3", image3.getBytes())
+                        .param("classId", "1")
+                        .param("lessonId", "1")
+                        .param("contents", "This is a valid content.")
+                        .param("rating", "5.1") // 5 초과
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.errors[0].field").value("rating"))
+                .andExpect(jsonPath("$.errors[0].message").value("평점은 0 이상 5 이하로 입력해 주세요."))
+        ;
+    }
+
+    @Test
+    @DisplayName("리뷰 등록 실패 - 이미 등록된 리뷰")
+    void registerReview_fail_already_register_review() throws Exception {
+        // Given
+        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
+        given(reviewService.registerReview(any(User.class), any(RegisterReviewDto.Request.class)))
+                .willThrow(new RestApiException(REVIEW_ALREADY_EXISTS));
+
+        // When & Then
+        mockMvc.perform(multipart(HttpMethod.POST, "/api/reviews")
+                        .file("image1", image1.getBytes())
+                        .file("image2", image2.getBytes())
+                        .file("image3", image3.getBytes())
+                        .param("classId", "1")
+                        .param("lessonId", "1")
+                        .param("contents", "This is a valid content.")
+                        .param("rating", "4.5") // 5 초과
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(REVIEW_ALREADY_EXISTS.name()))
+                .andExpect(jsonPath("$.message").value(REVIEW_ALREADY_EXISTS.getDescription()))
+        ;
+
+    }
+
+    @Test
+    @DisplayName("리뷰 수정 성공")
+    void updateReview_success() throws Exception {
+        // Given
+        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
+        given(reviewService.updateReview(
+                any(User.class), any(UpdateReviewDto.Request.class), any(Long.class)
+        )).willReturn(new UpdateReviewDto.Response(1L, "updated review contents", 4.5));
+
+        // When & Then
+        mockMvc.perform(MockMvcRequestBuilders
+                        .multipart(HttpMethod.PUT, "/api/reviews/{reviewId}", 1L)
+                        .file("image1", image1.getBytes())
+                        .file("image2", image2.getBytes())
+                        .file("image3", image3.getBytes())
+                        .param("contents", "updated review contents")
+                        .param("rating", "4.5")
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.reviewId").value(1L))
+                .andExpect(jsonPath("$.data.contents").value("updated review contents"))
+                .andExpect(jsonPath("$.data.rating").value(4.5))
+        ;
+    }
+
+    @Test
+    @DisplayName("리뷰 수정 실패 - 리뷰 내용 길이 미달")
+    void updateReview_fail_contents_too_short() throws Exception {
+        // Given
+        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
+
+        // When & Then
+        mockMvc.perform(MockMvcRequestBuilders
+                        .multipart(HttpMethod.PUT, "/api/reviews/{reviewId}", 1L)
+                        .file("image1", image1.getBytes())
+                        .file("image2", image2.getBytes())
+                        .file("image3", image3.getBytes())
+                        .param("contents", "short") // 10자 미만
+                        .param("rating", "4.5")
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.errors[0].field").value("contents"))
+                .andExpect(jsonPath("$.errors[0].message").value("리뷰 내용은 10자 이상 200자 이하로 입력해 주세요."))
+        ;
+    }
+
+    @Test
+    @DisplayName("리뷰 수정 실패 - 평점 범위 초과")
+    void updateReview_fail_rating_out_of_range() throws Exception {
+        // Given
+        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
+
+        // When & Then
+        mockMvc.perform(MockMvcRequestBuilders
+                        .multipart(HttpMethod.PUT, "/api/reviews/{reviewId}", 1L)
+                        .file("image1", image1.getBytes())
+                        .file("image2", image2.getBytes())
+                        .file("image3", image3.getBytes())
+                        .param("contents", "This is a valid content.")
+                        .param("rating", "5.1") // 5 초과
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.errors[0].field").value("rating"))
+                .andExpect(jsonPath("$.errors[0].message").value("평점은 0 이상 5 이하로 입력해 주세요."))
+        ;
+    }
+
+    @Test
+    @DisplayName("리뷰 수정 실패 - 리뷰 작성자가 아닌 사용자")
+    void updateReview_fail_not_review_owner() throws Exception {
+        // Given
+        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
+        given(reviewService.updateReview(any(User.class), any(UpdateReviewDto.Request.class),
+                any(Long.class))
+        ).willThrow(new RestApiException(NOT_REVIEW_OWNER));
+
+        // When & Then
+        mockMvc.perform(MockMvcRequestBuilders
+                        .multipart(HttpMethod.PUT, "/api/reviews/{reviewId}", 1L)
+                        .file("image1", image1.getBytes())
+                        .file("image2", image2.getBytes())
+                        .file("image3", image3.getBytes())
+                        .param("contents", "This is a valid content.")
+                        .param("rating", "4.5")
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andDo(print())
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(NOT_REVIEW_OWNER.name()))
+                .andExpect(jsonPath("$.message").value(NOT_REVIEW_OWNER.getDescription()))
+        ;
+    }
+
+    @Test
+    @DisplayName("리뷰 수정 실패 - 존재 하지 않는 리뷰 ID")
+    void updateReview_fail_not_exist_review_id() throws Exception {
+        // Given
+        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
+        given(reviewService.updateReview(any(User.class), any(UpdateReviewDto.Request.class),
+                any(Long.class))
+        ).willThrow(new RestApiException(REVIEW_NOT_FOUND));
+
+        // When & Then
+        mockMvc.perform(MockMvcRequestBuilders
+                        .multipart(HttpMethod.PUT, "/api/reviews/{reviewId}", 1L)
+                        .file("image1", image1.getBytes())
+                        .file("image2", image2.getBytes())
+                        .file("image3", image3.getBytes())
+                        .param("contents", "This is a valid content.")
+                        .param("rating", "4.5")
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(REVIEW_NOT_FOUND.name()))
+                .andExpect(jsonPath("$.message").value(REVIEW_NOT_FOUND.getDescription()))
+        ;
+    }
+
+    @Test
+    @DisplayName("리뷰 삭제 성공")
+    void deleteReview_success() throws Exception {
+        // Given
+        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
+        given(reviewService.deleteReview(any(User.class), any(Long.class))
+        ).willReturn(new DeleteReviewResponse(1L));
+
+        // When & Then
+        mockMvc.perform(MockMvcRequestBuilders
+                        .delete("/api/reviews/{reviewId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.reviewId").value(1L))
+        ;
+    }
+
+    @Test
+    @DisplayName("리뷰 삭제 실패 - 리뷰 작성자가 아닌 사용자")
+    void deleteReview_fail_not_review_owner() throws Exception {
+        // Given
+        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
+        given(reviewService.deleteReview(any(User.class), any(Long.class))
+        ).willThrow(new RestApiException(NOT_REVIEW_OWNER));
+
+        // When & Then
+        mockMvc.perform(MockMvcRequestBuilders
+                        .delete("/api/reviews/{reviewId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(NOT_REVIEW_OWNER.name()))
+                .andExpect(jsonPath("$.message").value(NOT_REVIEW_OWNER.getDescription()))
+        ;
+    }
+
+}


### PR DESCRIPTION
### 변경사항

**설정과 관련된 부분**
- `application-local.yml` 파일에 공통으로 사용하는 변수에 대해서 아래와 같이 환경 변수 설정을 추가하였습니다.
![image](https://github.com/ClassBridge/ClassBridge-BE/assets/152583754/4a38cd5e-d397-45cb-bb85-53fd92194e93)
`.env`파일에 공통으로 사용 할 시크릿 키 값 등을 담아두고 공통으로 관리하기 위한 목적으로 사용합니다.

- `dataloader/InitDataLoader` 에 어플리케이션 실행 시 유저, 클래스, 레슨의 필수 정보만을 가지는 데이터 로더를 작성하였습니다. 4명이 각자 작업 중인 엔티티가 통합되어 있지 않기 때문에 그 전까지 개발 및 테스트를 위해 유지하고, 엔티티가 통합 된 이후에는 삭제 할 예정입니다.

AWS S3 관련
- `config/S3Config` 파일에 S3 연결을 위한 설정 파일을 작성하였습니다.
- `service/S3Service` 파일에 이미지 파일 업로드 ,삭제 메서드를 구현해 두었습니다. 이미지 업로드가 필요하신 분은 사용하시면 될거같습니다.
![image](https://github.com/ClassBridge/ClassBridge-BE/assets/152583754/df004226-ef12-4a40-8651-c58af49d6a0b)

- 전역 변수로 허용 할 확장자 배열, 기능 별 사용할 폴더를 작성해두었으니, 연관된 파트의 개발자 분은 참고 하셔서 도메인 별로 폴더를 나눠서 이미지를 업로드 해주시면 될거같습니다.
![image](https://github.com/ClassBridge/ClassBridge-BE/assets/152583754/0b69d54f-102f-4a9f-aa57-d71f5218cb47)


**기능과 관련된 부분**
아래의 api를 추가하였습니다.
- **POST: /api/reviews** : 리뷰 작성
- **PUT: /api/reviews/{reviewId}** : 리뷰 수정
- **POST: /api/reviews/{reviewId}** : 리뷰 삭제

- 주의 사항
현재 유저 인증 기능이 구현되지 않아, 위의 데이터 로더에서 생성된 유저를 하드코딩된 ID 값으로 가져오는 식으로 구현해두었습니다. 이후 유저 인증 기능이 구현되면, 이 부분 수정하여 다시 PR 작성하도록 하겠습니다.
![image](https://github.com/ClassBridge/ClassBridge-BE/assets/152583754/974ae1ab-a94e-4eea-9a13-cb082a668acc)

### 테스트

- [x] 테스트 코드
- [x] API 테스트 

close #19 