### PR TITLE
feat(review) : add getting review detail functionality and add test code about Creation of review 

### DIFF
--- a/src/main/java/com/linked/classbridge/config/WebConfig.java
+++ b/src/main/java/com/linked/classbridge/config/WebConfig.java
@@ -1,0 +1,11 @@
+package com.linked.classbridge.config;
+
+import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+
+@Configuration
+@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
+public class WebConfig {
+}

--- a/src/main/java/com/linked/classbridge/controller/OneDayClassController.java
+++ b/src/main/java/com/linked/classbridge/controller/OneDayClassController.java
@@ -1,0 +1,36 @@
+package com.linked.classbridge.controller;
+
+import com.linked.classbridge.dto.SuccessResponse;
+import com.linked.classbridge.dto.review.GetReviewResponse;
+import com.linked.classbridge.service.ReviewService;
+import com.linked.classbridge.type.ResponseMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/class")
+public class OneDayClassController {
+
+    private final ReviewService reviewService;
+
+    @GetMapping("/{classId}/reviews")
+    public ResponseEntity<SuccessResponse<Slice<GetReviewResponse>>> getClassReviews(
+            @PathVariable Long classId,
+            @PageableDefault Pageable pageable
+    ) {
+        return ResponseEntity.ok().body(
+                SuccessResponse.of(
+                        ResponseMessage.REVIEW_GET_SUCCESS,
+                        reviewService.getClassReviews(classId, pageable)
+                )
+        );
+    }
+}

--- a/src/main/java/com/linked/classbridge/controller/OneDayClassController.java
+++ b/src/main/java/com/linked/classbridge/controller/OneDayClassController.java
@@ -4,6 +4,7 @@ import com.linked.classbridge.dto.SuccessResponse;
 import com.linked.classbridge.dto.review.GetReviewResponse;
 import com.linked.classbridge.service.ReviewService;
 import com.linked.classbridge.type.ResponseMessage;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -21,6 +22,7 @@ public class OneDayClassController {
 
     private final ReviewService reviewService;
 
+    @Operation(summary = "클래스 리뷰 조회", description = "클래스 리뷰 조회")
     @GetMapping("/{classId}/reviews")
     public ResponseEntity<SuccessResponse<Slice<GetReviewResponse>>> getClassReviews(
             @PathVariable Long classId,

--- a/src/main/java/com/linked/classbridge/controller/OneDayClassController.java
+++ b/src/main/java/com/linked/classbridge/controller/OneDayClassController.java
@@ -6,8 +6,8 @@ import com.linked.classbridge.service.ReviewService;
 import com.linked.classbridge.type.ResponseMessage;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -24,7 +24,7 @@ public class OneDayClassController {
 
     @Operation(summary = "클래스 리뷰 조회", description = "클래스 리뷰 조회")
     @GetMapping("/{classId}/reviews")
-    public ResponseEntity<SuccessResponse<Slice<GetReviewResponse>>> getClassReviews(
+    public ResponseEntity<SuccessResponse<Page<GetReviewResponse>>> getClassReviews(
             @PathVariable Long classId,
             @PageableDefault Pageable pageable
     ) {

--- a/src/main/java/com/linked/classbridge/controller/ReviewController.java
+++ b/src/main/java/com/linked/classbridge/controller/ReviewController.java
@@ -2,6 +2,8 @@ package com.linked.classbridge.controller;
 
 import com.linked.classbridge.domain.User;
 import com.linked.classbridge.dto.SuccessResponse;
+import com.linked.classbridge.dto.review.DeleteReviewResponse;
+import com.linked.classbridge.dto.review.GetReviewResponse;
 import com.linked.classbridge.dto.review.RegisterReviewDto;
 import com.linked.classbridge.dto.review.UpdateReviewDto;
 import com.linked.classbridge.repository.UserRepository;
@@ -29,7 +31,7 @@ public class ReviewController {
     private final ReviewService reviewService;
 
     @PostMapping
-    public ResponseEntity<SuccessResponse<?>> registerReview(
+    public ResponseEntity<SuccessResponse<RegisterReviewDto.Response>> registerReview(
             @Valid @ModelAttribute RegisterReviewDto.Request request
     ) {
         User user = userRepository.findById(1L).orElse(null);
@@ -43,7 +45,7 @@ public class ReviewController {
     }
 
     @PutMapping("/{reviewId}")
-    public ResponseEntity<SuccessResponse<?>> updateReview(
+    public ResponseEntity<SuccessResponse<UpdateReviewDto.Response>> updateReview(
             @Valid @ModelAttribute UpdateReviewDto.Request request,
             @PathVariable Long reviewId
     ) {
@@ -58,7 +60,7 @@ public class ReviewController {
     }
 
     @DeleteMapping("/{reviewId}")
-    public ResponseEntity<SuccessResponse<?>> deleteReview(
+    public ResponseEntity<SuccessResponse<DeleteReviewResponse>> deleteReview(
             @PathVariable Long reviewId
     ) {
         User user = userRepository.findById(1L).orElse(null);
@@ -70,9 +72,9 @@ public class ReviewController {
                 )
         );
     }
-    
+
     @GetMapping("/{reviewId}")
-    public ResponseEntity<SuccessResponse<?>> getReview(
+    public ResponseEntity<SuccessResponse<GetReviewResponse>> getReview(
             @PathVariable Long reviewId
     ) {
         return ResponseEntity.status(HttpStatus.OK).body(

--- a/src/main/java/com/linked/classbridge/controller/ReviewController.java
+++ b/src/main/java/com/linked/classbridge/controller/ReviewController.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -66,6 +67,18 @@ public class ReviewController {
                 SuccessResponse.of(
                         ResponseMessage.REVIEW_DELETE_SUCCESS,
                         reviewService.deleteReview(user, reviewId)
+                )
+        );
+    }
+    
+    @GetMapping("/{reviewId}")
+    public ResponseEntity<SuccessResponse<?>> getReview(
+            @PathVariable Long reviewId
+    ) {
+        return ResponseEntity.status(HttpStatus.OK).body(
+                SuccessResponse.of(
+                        ResponseMessage.REVIEW_GET_SUCCESS,
+                        reviewService.getReview(reviewId)
                 )
         );
     }

--- a/src/main/java/com/linked/classbridge/controller/ReviewController.java
+++ b/src/main/java/com/linked/classbridge/controller/ReviewController.java
@@ -9,6 +9,7 @@ import com.linked.classbridge.dto.review.UpdateReviewDto;
 import com.linked.classbridge.repository.UserRepository;
 import com.linked.classbridge.service.ReviewService;
 import com.linked.classbridge.type.ResponseMessage;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -30,6 +31,7 @@ public class ReviewController {
     private final UserRepository userRepository;
     private final ReviewService reviewService;
 
+    @Operation(summary = "리뷰 등록", description = "리뷰 등록")
     @PostMapping
     public ResponseEntity<SuccessResponse<RegisterReviewDto.Response>> registerReview(
             @Valid @ModelAttribute RegisterReviewDto.Request request
@@ -44,6 +46,7 @@ public class ReviewController {
         );
     }
 
+    @Operation(summary = "리뷰 수정", description = "리뷰 수정")
     @PutMapping("/{reviewId}")
     public ResponseEntity<SuccessResponse<UpdateReviewDto.Response>> updateReview(
             @Valid @ModelAttribute UpdateReviewDto.Request request,
@@ -59,6 +62,7 @@ public class ReviewController {
         );
     }
 
+    @Operation(summary = "리뷰 삭제", description = "리뷰 삭제")
     @DeleteMapping("/{reviewId}")
     public ResponseEntity<SuccessResponse<DeleteReviewResponse>> deleteReview(
             @PathVariable Long reviewId
@@ -73,6 +77,7 @@ public class ReviewController {
         );
     }
 
+    @Operation(summary = "리뷰 조회", description = "리뷰 조회")
     @GetMapping("/{reviewId}")
     public ResponseEntity<SuccessResponse<GetReviewResponse>> getReview(
             @PathVariable Long reviewId

--- a/src/main/java/com/linked/classbridge/controller/TutorController.java
+++ b/src/main/java/com/linked/classbridge/controller/TutorController.java
@@ -8,8 +8,8 @@ import com.linked.classbridge.service.ReviewService;
 import com.linked.classbridge.type.ResponseMessage;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,7 +27,7 @@ public class TutorController {
 
     @Operation(summary = "강사 리뷰 조회", description = "강사 리뷰 조회")
     @GetMapping("/reviews")
-    public ResponseEntity<SuccessResponse<Slice<GetReviewResponse>>> getClassReviews(
+    public ResponseEntity<SuccessResponse<Page<GetReviewResponse>>> getClassReviews(
             @PageableDefault Pageable pageable
     ) {
 

--- a/src/main/java/com/linked/classbridge/controller/TutorController.java
+++ b/src/main/java/com/linked/classbridge/controller/TutorController.java
@@ -6,6 +6,7 @@ import com.linked.classbridge.dto.review.GetReviewResponse;
 import com.linked.classbridge.repository.UserRepository;
 import com.linked.classbridge.service.ReviewService;
 import com.linked.classbridge.type.ResponseMessage;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -24,6 +25,7 @@ public class TutorController {
 
     private final UserRepository userRepository;
 
+    @Operation(summary = "강사 리뷰 조회", description = "강사 리뷰 조회")
     @GetMapping("/reviews")
     public ResponseEntity<SuccessResponse<Slice<GetReviewResponse>>> getClassReviews(
             @PageableDefault Pageable pageable

--- a/src/main/java/com/linked/classbridge/controller/TutorController.java
+++ b/src/main/java/com/linked/classbridge/controller/TutorController.java
@@ -1,0 +1,41 @@
+package com.linked.classbridge.controller;
+
+import com.linked.classbridge.domain.User;
+import com.linked.classbridge.dto.SuccessResponse;
+import com.linked.classbridge.dto.review.GetReviewResponse;
+import com.linked.classbridge.repository.UserRepository;
+import com.linked.classbridge.service.ReviewService;
+import com.linked.classbridge.type.ResponseMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/tutors")
+public class TutorController {
+
+    private final ReviewService reviewService;
+
+    private final UserRepository userRepository;
+
+    @GetMapping("/reviews")
+    public ResponseEntity<SuccessResponse<Slice<GetReviewResponse>>> getClassReviews(
+            @PageableDefault Pageable pageable
+    ) {
+
+        User tutor = userRepository.findById(1L).orElse(null);
+
+        return ResponseEntity.ok().body(
+                SuccessResponse.of(
+                        ResponseMessage.REVIEW_GET_SUCCESS,
+                        reviewService.getTutorReviews(tutor, pageable)
+                )
+        );
+    }
+}

--- a/src/main/java/com/linked/classbridge/controller/UserController.java
+++ b/src/main/java/com/linked/classbridge/controller/UserController.java
@@ -1,0 +1,42 @@
+package com.linked.classbridge.controller;
+
+import com.linked.classbridge.domain.User;
+import com.linked.classbridge.dto.SuccessResponse;
+import com.linked.classbridge.dto.review.GetReviewResponse;
+import com.linked.classbridge.repository.UserRepository;
+import com.linked.classbridge.service.ReviewService;
+import com.linked.classbridge.type.ResponseMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final ReviewService reviewService;
+
+    private final UserRepository userRepository;
+
+    @GetMapping("/reviews")
+    public ResponseEntity<SuccessResponse<Slice<GetReviewResponse>>> getClassReviews(
+            @PageableDefault Pageable pageable
+    ) {
+
+        User user = userRepository.findById(1L).orElse(null);
+
+        return ResponseEntity.ok().body(
+                SuccessResponse.of(
+                        ResponseMessage.REVIEW_GET_SUCCESS,
+                        reviewService.getUserReviews(user, pageable)
+                )
+        );
+    }
+}

--- a/src/main/java/com/linked/classbridge/controller/UserController.java
+++ b/src/main/java/com/linked/classbridge/controller/UserController.java
@@ -6,6 +6,7 @@ import com.linked.classbridge.dto.review.GetReviewResponse;
 import com.linked.classbridge.repository.UserRepository;
 import com.linked.classbridge.service.ReviewService;
 import com.linked.classbridge.type.ResponseMessage;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -25,6 +26,7 @@ public class UserController {
 
     private final UserRepository userRepository;
 
+    @Operation(summary = "수강생 리뷰 조회", description = "수강생 리뷰 조회")
     @GetMapping("/reviews")
     public ResponseEntity<SuccessResponse<Slice<GetReviewResponse>>> getClassReviews(
             @PageableDefault Pageable pageable

--- a/src/main/java/com/linked/classbridge/controller/UserController.java
+++ b/src/main/java/com/linked/classbridge/controller/UserController.java
@@ -8,8 +8,8 @@ import com.linked.classbridge.service.ReviewService;
 import com.linked.classbridge.type.ResponseMessage;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,7 +28,7 @@ public class UserController {
 
     @Operation(summary = "수강생 리뷰 조회", description = "수강생 리뷰 조회")
     @GetMapping("/reviews")
-    public ResponseEntity<SuccessResponse<Slice<GetReviewResponse>>> getClassReviews(
+    public ResponseEntity<SuccessResponse<Page<GetReviewResponse>>> getClassReviews(
             @PageableDefault Pageable pageable
     ) {
 

--- a/src/main/java/com/linked/classbridge/domain/Lesson.java
+++ b/src/main/java/com/linked/classbridge/domain/Lesson.java
@@ -11,6 +11,7 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -39,4 +40,6 @@ public class Lesson extends BaseEntity {
 
     @OneToMany(mappedBy = "lesson", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Review> reviewList;
+
+    private LocalDateTime lessonDate;
 }

--- a/src/main/java/com/linked/classbridge/domain/Lesson.java
+++ b/src/main/java/com/linked/classbridge/domain/Lesson.java
@@ -42,4 +42,8 @@ public class Lesson extends BaseEntity {
     private List<Review> reviewList;
 
     private LocalDateTime lessonDate;
+
+    public void addReview(Review mockReview1) {
+        this.reviewList.add(mockReview1);
+    }
 }

--- a/src/main/java/com/linked/classbridge/domain/OneDayClass.java
+++ b/src/main/java/com/linked/classbridge/domain/OneDayClass.java
@@ -37,6 +37,8 @@ public class OneDayClass extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User tutor;
 
+    private String className;
+
     private Double totalStarRate;
 
     private Integer totalReviews;

--- a/src/main/java/com/linked/classbridge/domain/Review.java
+++ b/src/main/java/com/linked/classbridge/domain/Review.java
@@ -59,4 +59,8 @@ public class Review extends BaseEntity {
         this.contents = contents;
         this.rating = rating;
     }
+
+    public void addReviewImage(ReviewImage reviewImage) {
+        reviewImageList.add(reviewImage);
+    }
 }

--- a/src/main/java/com/linked/classbridge/domain/Review.java
+++ b/src/main/java/com/linked/classbridge/domain/Review.java
@@ -13,9 +13,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.util.List;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
@@ -42,6 +44,7 @@ public class Review extends BaseEntity {
     @JoinColumn(name = "lesson_id")
     private Lesson lesson;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "one_day_class_id")
     private OneDayClass oneDayClass;
@@ -54,6 +57,23 @@ public class Review extends BaseEntity {
 
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL)
     private List<ReviewImage> reviewImageList;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Review review = (Review) o;
+        return Objects.equals(reviewId, review.reviewId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(reviewId);
+    }
 
     public void update(String contents, Double rating) {
         this.contents = contents;

--- a/src/main/java/com/linked/classbridge/domain/User.java
+++ b/src/main/java/com/linked/classbridge/domain/User.java
@@ -44,4 +44,8 @@ public class User extends BaseEntity {
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Review> reviewList;
+
+    public void addReview(Review mockReview1) {
+        this.reviewList.add(mockReview1);
+    }
 }

--- a/src/main/java/com/linked/classbridge/dto/review/GetReviewResponse.java
+++ b/src/main/java/com/linked/classbridge/dto/review/GetReviewResponse.java
@@ -1,0 +1,40 @@
+package com.linked.classbridge.dto.review;
+
+import com.linked.classbridge.domain.Review;
+import com.linked.classbridge.domain.ReviewImage;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record GetReviewResponse(
+        Long reviewId,
+        Long classId,
+        String className,
+        Long lessonId,
+        Long userId,
+        String userNickName,
+        Double rating,
+        String contents,
+        LocalDateTime lessonDate,
+        LocalDateTime createdAt,
+        List<String> reviewImageUrlList
+) {
+    public static GetReviewResponse fromEntity(Review review) {
+
+        return new GetReviewResponse(
+                review.getReviewId(),
+                review.getOneDayClass().getOneDayClassId(),
+                review.getOneDayClass().getClassName(),
+                review.getLesson().getLessonId(),
+                review.getUser().getUserId(),
+                review.getUser().getNickname(),
+                review.getRating(),
+                review.getContents(),
+                review.getLesson().getLessonDate(),
+                review.getCreatedAt(),
+                review.getReviewImageList().stream()
+                        .map(ReviewImage::getUrl)
+                        .toList()
+        );
+
+    }
+}

--- a/src/main/java/com/linked/classbridge/repository/ReviewRepository.java
+++ b/src/main/java/com/linked/classbridge/repository/ReviewRepository.java
@@ -15,4 +15,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     Optional<Review> findByLessonAndUser(Lesson lesson, User user);
 
     Slice<Review> findByOneDayClass(OneDayClass oneDayClass, Pageable pageable);
+
+    Slice<Review> findByUser(User user, Pageable pageable);
 }

--- a/src/main/java/com/linked/classbridge/repository/ReviewRepository.java
+++ b/src/main/java/com/linked/classbridge/repository/ReviewRepository.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -17,4 +18,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     Slice<Review> findByOneDayClass(OneDayClass oneDayClass, Pageable pageable);
 
     Slice<Review> findByUser(User user, Pageable pageable);
+
+    @Query("SELECT r FROM Review r WHERE r.oneDayClass.tutor = :tutor")
+    Slice<Review> findByTutor(User tutor, Pageable pageable);
 }

--- a/src/main/java/com/linked/classbridge/repository/ReviewRepository.java
+++ b/src/main/java/com/linked/classbridge/repository/ReviewRepository.java
@@ -1,13 +1,18 @@
 package com.linked.classbridge.repository;
 
 import com.linked.classbridge.domain.Lesson;
+import com.linked.classbridge.domain.OneDayClass;
 import com.linked.classbridge.domain.Review;
 import com.linked.classbridge.domain.User;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     Optional<Review> findByLessonAndUser(Lesson lesson, User user);
+
+    Slice<Review> findByOneDayClass(OneDayClass oneDayClass, Pageable pageable);
 }

--- a/src/main/java/com/linked/classbridge/repository/ReviewRepository.java
+++ b/src/main/java/com/linked/classbridge/repository/ReviewRepository.java
@@ -5,8 +5,8 @@ import com.linked.classbridge.domain.OneDayClass;
 import com.linked.classbridge.domain.Review;
 import com.linked.classbridge.domain.User;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -15,10 +15,10 @@ import org.springframework.stereotype.Repository;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     Optional<Review> findByLessonAndUser(Lesson lesson, User user);
 
-    Slice<Review> findByOneDayClass(OneDayClass oneDayClass, Pageable pageable);
+    Page<Review> findByOneDayClass(OneDayClass oneDayClass, Pageable pageable);
 
-    Slice<Review> findByUser(User user, Pageable pageable);
+    Page<Review> findByUser(User user, Pageable pageable);
 
     @Query("SELECT r FROM Review r WHERE r.oneDayClass.tutor = :tutor")
-    Slice<Review> findByTutor(User tutor, Pageable pageable);
+    Page<Review> findByTutor(User tutor, Pageable pageable);
 }

--- a/src/main/java/com/linked/classbridge/service/OneDayClassService.java
+++ b/src/main/java/com/linked/classbridge/service/OneDayClassService.java
@@ -1,0 +1,22 @@
+package com.linked.classbridge.service;
+
+import com.linked.classbridge.domain.OneDayClass;
+import com.linked.classbridge.exception.RestApiException;
+import com.linked.classbridge.repository.OneDayClassRepository;
+import com.linked.classbridge.type.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OneDayClassService {
+
+    private final OneDayClassRepository oneDayClassRepository;
+
+    public OneDayClass findClassById(Long classId) {
+        return oneDayClassRepository.findById(classId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.CLASS_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/linked/classbridge/service/ReviewService.java
+++ b/src/main/java/com/linked/classbridge/service/ReviewService.java
@@ -223,4 +223,16 @@ public class ReviewService {
 
         return reviews.map(GetReviewResponse::fromEntity);
     }
+
+    /**
+     * 사용자 리뷰 조회
+     *
+     * @param user     사용자
+     * @param pageable 페이징 정보
+     * @return 리뷰 응답
+     */
+    public Slice<GetReviewResponse> getUserReviews(User user, Pageable pageable) {
+        Slice<Review> reviews = reviewRepository.findByUser(user, pageable);
+        return reviews.map(GetReviewResponse::fromEntity);
+    }
 }

--- a/src/main/java/com/linked/classbridge/service/ReviewService.java
+++ b/src/main/java/com/linked/classbridge/service/ReviewService.java
@@ -6,6 +6,7 @@ import com.linked.classbridge.domain.Review;
 import com.linked.classbridge.domain.ReviewImage;
 import com.linked.classbridge.domain.User;
 import com.linked.classbridge.dto.review.DeleteReviewResponse;
+import com.linked.classbridge.dto.review.GetReviewResponse;
 import com.linked.classbridge.dto.review.RegisterReviewDto;
 import com.linked.classbridge.dto.review.RegisterReviewDto.Request;
 import com.linked.classbridge.dto.review.UpdateReviewDto;
@@ -190,5 +191,10 @@ public class ReviewService {
             }
             sequence++;
         }
+    }
+
+    public GetReviewResponse getReview(Long reviewId) {
+        Review review = findReviewById(reviewId);
+        return GetReviewResponse.fromEntity(review);
     }
 }

--- a/src/main/java/com/linked/classbridge/service/ReviewService.java
+++ b/src/main/java/com/linked/classbridge/service/ReviewService.java
@@ -17,6 +17,8 @@ import com.linked.classbridge.type.ErrorCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -29,6 +31,8 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
 
     private final ReviewImageRepository reviewImageRepository;
+
+    private final OneDayClassService oneDayClassService;
 
     private final LessonService lessonService;
 
@@ -193,8 +197,30 @@ public class ReviewService {
         }
     }
 
+    /**
+     * 리뷰 조회
+     *
+     * @param reviewId 리뷰 ID
+     * @return 리뷰 응답
+     */
     public GetReviewResponse getReview(Long reviewId) {
         Review review = findReviewById(reviewId);
         return GetReviewResponse.fromEntity(review);
+    }
+
+    /**
+     * 클래스 리뷰 조회
+     *
+     * @param classId  클래스 ID
+     * @param pageable 페이징 정보
+     * @return 리뷰 응답
+     */
+    public Slice<GetReviewResponse> getClassReviews(Long classId, Pageable pageable) {
+
+        OneDayClass oneDayClass = oneDayClassService.findClassById(classId);
+
+        Slice<Review> reviews = reviewRepository.findByOneDayClass(oneDayClass, pageable);
+
+        return reviews.map(GetReviewResponse::fromEntity);
     }
 }

--- a/src/main/java/com/linked/classbridge/service/ReviewService.java
+++ b/src/main/java/com/linked/classbridge/service/ReviewService.java
@@ -17,8 +17,8 @@ import com.linked.classbridge.type.ErrorCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -215,11 +215,11 @@ public class ReviewService {
      * @param pageable 페이징 정보
      * @return 리뷰 응답
      */
-    public Slice<GetReviewResponse> getClassReviews(Long classId, Pageable pageable) {
+    public Page<GetReviewResponse> getClassReviews(Long classId, Pageable pageable) {
 
         OneDayClass oneDayClass = oneDayClassService.findClassById(classId);
 
-        Slice<Review> reviews = reviewRepository.findByOneDayClass(oneDayClass, pageable);
+        Page<Review> reviews = reviewRepository.findByOneDayClass(oneDayClass, pageable);
 
         return reviews.map(GetReviewResponse::fromEntity);
     }
@@ -231,8 +231,8 @@ public class ReviewService {
      * @param pageable 페이징 정보
      * @return 리뷰 응답
      */
-    public Slice<GetReviewResponse> getUserReviews(User user, Pageable pageable) {
-        Slice<Review> reviews = reviewRepository.findByUser(user, pageable);
+    public Page<GetReviewResponse> getUserReviews(User user, Pageable pageable) {
+        Page<Review> reviews = reviewRepository.findByUser(user, pageable);
         return reviews.map(GetReviewResponse::fromEntity);
     }
 
@@ -244,8 +244,8 @@ public class ReviewService {
      * @return 리뷰 응답
      */
 
-    public Slice<GetReviewResponse> getTutorReviews(User tutor, Pageable pageable) {
-        Slice<Review> reviews = reviewRepository.findByTutor(tutor, pageable);
+    public Page<GetReviewResponse> getTutorReviews(User tutor, Pageable pageable) {
+        Page<Review> reviews = reviewRepository.findByTutor(tutor, pageable);
         return reviews.map(GetReviewResponse::fromEntity);
     }
 }

--- a/src/main/java/com/linked/classbridge/service/ReviewService.java
+++ b/src/main/java/com/linked/classbridge/service/ReviewService.java
@@ -235,4 +235,17 @@ public class ReviewService {
         Slice<Review> reviews = reviewRepository.findByUser(user, pageable);
         return reviews.map(GetReviewResponse::fromEntity);
     }
+
+    /**
+     * 강사 리뷰 조회
+     *
+     * @param tutor    강사
+     * @param pageable 페이징 정보
+     * @return 리뷰 응답
+     */
+
+    public Slice<GetReviewResponse> getTutorReviews(User tutor, Pageable pageable) {
+        Slice<Review> reviews = reviewRepository.findByTutor(tutor, pageable);
+        return reviews.map(GetReviewResponse::fromEntity);
+    }
 }

--- a/src/main/java/com/linked/classbridge/type/ErrorCode.java
+++ b/src/main/java/com/linked/classbridge/type/ErrorCode.java
@@ -27,7 +27,7 @@ public enum ErrorCode {
     LESSON_NOT_FOUND(HttpStatus.BAD_REQUEST, "클래스를 찾을 수 없습니다."),
     REVIEW_NOT_FOUND(HttpStatus.BAD_REQUEST, "리뷰를 찾을 수 없습니다."),
     NOT_REVIEW_OWNER(HttpStatus.FORBIDDEN, "리뷰 작성자만 수정 및 삭제가 가능합니다."),
-    ;
+    CLASS_NOT_FOUND(HttpStatus.BAD_REQUEST, "원데이 클래스를 찾을 수 없습니다.");
     private final HttpStatus httpStatus;
     private final String description;
 }

--- a/src/main/java/com/linked/classbridge/type/ResponseMessage.java
+++ b/src/main/java/com/linked/classbridge/type/ResponseMessage.java
@@ -12,7 +12,7 @@ public enum ResponseMessage {
     REVIEW_REGISTER_SUCCESS("리뷰 등록 성공"),
     REVIEW_UPDATE_SUCCESS("리뷰 수정 성공"),
     REVIEW_DELETE_SUCCESS("리뷰 삭제 성공"),
+    REVIEW_GET_SUCCESS("리뷰 조회 성공"),
     ;
-
     private final String message;
 }

--- a/src/test/java/com/linked/classbridge/controller/OneDayClassControllerTest.java
+++ b/src/test/java/com/linked/classbridge/controller/OneDayClassControllerTest.java
@@ -1,0 +1,115 @@
+package com.linked.classbridge.controller;
+
+import static com.linked.classbridge.type.ErrorCode.CLASS_NOT_FOUND;
+import static com.linked.classbridge.type.ResponseMessage.REVIEW_GET_SUCCESS;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.linked.classbridge.dto.review.GetReviewResponse;
+import com.linked.classbridge.exception.RestApiException;
+import com.linked.classbridge.service.ReviewService;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(OneDayClassController.class)
+@TestPropertySource(properties = "spring.config.location=classpath:application-test.yml")
+class OneDayClassControllerTest {
+
+    @MockBean
+    private ReviewService reviewService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private Pageable pageable;
+    private GetReviewResponse reviewResponse1;
+    private GetReviewResponse reviewResponse2;
+
+    @BeforeEach
+    void setUp() {
+        // 0페이지, 5개, 내림차순, createdAt 기준
+        pageable = PageRequest.of(0, 5, Direction.DESC, "createdAt");
+        reviewResponse1 = new GetReviewResponse(
+                1L, 1L, "className", 1L, 1L,
+                "userNickname1", 4.5, "content1",
+                LocalDateTime.of(2024, 6, 1, 9, 0),
+                LocalDateTime.of(2024, 6, 3, 15, 0),
+                List.of("url1", "url2", "url3")
+        );
+        reviewResponse2 = new GetReviewResponse(
+                2L, 1L, "className", 2L, 2L,
+                "userNickname2", 2.3, "content2",
+                LocalDateTime.of(2024, 6, 1, 12, 0),
+                LocalDateTime.of(2024, 6, 2, 17, 0),
+                List.of("url4", "url5", "url6")
+        );
+    }
+
+    @Test
+    @DisplayName("클래스 리뷰 목록 조회 성공")
+    void getClassReviews() throws Exception {
+        // given
+        given(reviewService.getClassReviews(1L, pageable)).willReturn(
+                new SliceImpl<>(Arrays.asList(reviewResponse1, reviewResponse2), pageable, true));
+
+        // when & then
+        mockMvc.perform(get("/api/class/{classId}/reviews", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("page", "0")
+                        .param("size", "5")
+                        .param("sort", "createdAt,desc")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.message").value(REVIEW_GET_SUCCESS.getMessage()))
+                .andExpect(jsonPath("$.data.content[0].reviewId").value(reviewResponse1.reviewId()))
+                .andExpect(jsonPath("$.data.content[0].classId").value(reviewResponse1.classId()))
+                .andExpect(jsonPath("$.data.content[0].userId").value(reviewResponse1.userId()))
+                .andExpect(jsonPath("$.data.content[0].rating").value(reviewResponse1.rating()))
+                .andExpect(jsonPath("$.data.content[0].contents").value(reviewResponse1.contents()))
+                .andExpect(jsonPath("$.data.content[1].reviewId").value(reviewResponse2.reviewId()))
+                .andExpect(jsonPath("$.data.content[1].classId").value(reviewResponse2.classId()))
+                .andExpect(jsonPath("$.data.content[1].userId").value(reviewResponse2.userId()))
+                .andExpect(jsonPath("$.data.content[1].rating").value(reviewResponse2.rating()))
+                .andExpect(jsonPath("$.data.content[1].contents").value(reviewResponse2.contents()))
+        ;
+    }
+
+    @Test
+    @DisplayName("클래스 리뷰 목록 조회 실패 - 존재하지 않는 클래스")
+    void getClassReviewsFail() throws Exception {
+        // given
+        given(reviewService.getClassReviews(1L, pageable)).willThrow(
+                new RestApiException(CLASS_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/api/class/{classId}/reviews", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("page", "0")
+                        .param("size", "5")
+                        .param("sort", "createdAt,desc")
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(CLASS_NOT_FOUND.name()))
+                .andExpect(jsonPath("$.message").value(CLASS_NOT_FOUND.getDescription()))
+        ;
+    }
+
+
+}

--- a/src/test/java/com/linked/classbridge/controller/OneDayClassControllerTest.java
+++ b/src/test/java/com/linked/classbridge/controller/OneDayClassControllerTest.java
@@ -19,9 +19,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
@@ -66,7 +66,7 @@ class OneDayClassControllerTest {
     void getClassReviews() throws Exception {
         // given
         given(reviewService.getClassReviews(1L, pageable)).willReturn(
-                new SliceImpl<>(Arrays.asList(reviewResponse1, reviewResponse2), pageable, true));
+                new PageImpl<>(Arrays.asList(reviewResponse1, reviewResponse2), pageable, 2));
 
         // when & then
         mockMvc.perform(get("/api/class/{classId}/reviews", 1L)

--- a/src/test/java/com/linked/classbridge/controller/ReviewControllerTest.java
+++ b/src/test/java/com/linked/classbridge/controller/ReviewControllerTest.java
@@ -3,7 +3,7 @@ package com.linked.classbridge.controller;
 import static com.linked.classbridge.type.ErrorCode.NOT_REVIEW_OWNER;
 import static com.linked.classbridge.type.ErrorCode.REVIEW_ALREADY_EXISTS;
 import static com.linked.classbridge.type.ErrorCode.REVIEW_NOT_FOUND;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -18,6 +18,7 @@ import com.linked.classbridge.dto.review.UpdateReviewDto;
 import com.linked.classbridge.exception.RestApiException;
 import com.linked.classbridge.repository.UserRepository;
 import com.linked.classbridge.service.ReviewService;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -25,8 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
@@ -35,8 +35,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-@SpringBootTest
-@AutoConfigureMockMvc
+@WebMvcTest(ReviewController.class)
 @TestPropertySource(properties = "spring.config.location=classpath:application-test.yml")
 class ReviewControllerTest {
 
@@ -49,57 +48,69 @@ class ReviewControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    MockMultipartFile image1;
-    MockMultipartFile image2;
-    MockMultipartFile image3;
+    private MockMultipartFile image1;
+    private MockMultipartFile image2;
+    private MockMultipartFile image3;
 
     @BeforeEach
     void setUp() {
-        image1 = new MockMultipartFile("images", "image1.jpg", "image/jpeg", "image1".getBytes());
-        image2 = new MockMultipartFile("images", "image2.jpg", "image/jpeg", "image2".getBytes());
-        image3 = new MockMultipartFile("images", "image3.jpg", "image/jpeg", "image3".getBytes());
-
+        image1 = new MockMultipartFile("image1", "image1.jpg", "image/jpeg",
+                "image1 content".getBytes(StandardCharsets.UTF_8));
+        image2 = new MockMultipartFile("image2", "image2.jpg", "image/jpeg",
+                "image2 content".getBytes(StandardCharsets.UTF_8));
+        image3 = new MockMultipartFile("image3", "image3.jpg", "image/jpeg",
+                "image3 content".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
     @DisplayName("리뷰 등록 성공")
     void registerReview_success() throws Exception {
         // Given
-        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
-        given(reviewService.registerReview(any(User.class), any(RegisterReviewDto.Request.class)))
-                .willReturn(new RegisterReviewDto.Response(1L));
+        User mockUser = User.builder().userId(1L).build();
 
+        RegisterReviewDto.Request request = new RegisterReviewDto.Request(
+                1L, 1L, "This is a valid content.", 4.5, image1, image2, image3);
+
+        RegisterReviewDto.Response response = new RegisterReviewDto.Response(1L);
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(mockUser));
+        given(reviewService.registerReview(eq(mockUser), eq(request))).willReturn(response);
         // When & Then
         mockMvc.perform(multipart("/api/reviews")
-                        .file("image1", image1.getBytes())
-                        .file("image2", image2.getBytes())
-                        .file("image3", image3.getBytes())
-                        .param("lessonId", "1")
-                        .param("classId", "1")
-                        .param("contents", "This is a valid content.")
-                        .param("rating", "4.5")
+                        .file(image1)
+                        .file(image2)
+                        .file(image3)
+                        .param("lessonId", request.lessonId().toString())
+                        .param("classId", request.classId().toString())
+                        .param("contents", request.contents())
+                        .param("rating", request.rating().toString())
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
                 .andDo(print())
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.code").value("SUCCESS"))
-                .andExpect(jsonPath("$.data.reviewId").value(1L))
-        ;
+                .andExpect(jsonPath("$.data.reviewId").value(response.reviewId()));
     }
 
     @Test
     @DisplayName("리뷰 등록 실패 - 레슨 ID 미입력")
     void registerReview_fail_lessonId_not_enter() throws Exception {
         // Given
-        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
+        User mockUser = User.builder().userId(1L).build();
+        RegisterReviewDto.Request request = new RegisterReviewDto.Request(
+                1L, null, "This is a valid content.", 4.5, image1, image2, image3);
+        RegisterReviewDto.Response response = new RegisterReviewDto.Response(1L);
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(mockUser));
+        given(reviewService.registerReview(eq(mockUser), eq(request))).willReturn(response);
 
         // When & Then
         mockMvc.perform(multipart("/api/reviews")
-                        .file("image1", image1.getBytes())
-                        .file("image2", image2.getBytes())
-                        .file("image3", image3.getBytes())
-                        .param("classId", "1")
-                        .param("contents", "This is a valid content.")
-                        .param("rating", "4.5")
+                        .file(image1)
+                        .file(image2)
+                        .file(image3)
+                        .param("classId", request.classId().toString())
+                        .param("contents", request.contents())
+                        .param("rating", request.rating().toString())
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
@@ -113,17 +124,23 @@ class ReviewControllerTest {
     @DisplayName("리뷰 등록 실패 - 리뷰 내용 길이 미달")
     void registerReview_fail_contents_too_short() throws Exception {
         // Given
-        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
+        User mockUser = User.builder().userId(1L).build();
+        RegisterReviewDto.Request request = new RegisterReviewDto.Request(
+                1L, 1L, "short", 4.5, image1, image2, image3);
+        RegisterReviewDto.Response response = new RegisterReviewDto.Response(1L);
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(mockUser));
+        given(reviewService.registerReview(eq(mockUser), eq(request))).willReturn(response);
 
         // When & Then
         mockMvc.perform(multipart("/api/reviews")
-                        .file("image1", image1.getBytes())
-                        .file("image2", image2.getBytes())
-                        .file("image3", image3.getBytes())
-                        .param("classId", "1")
-                        .param("lessonId", "1")
-                        .param("contents", "short") // 10자 미만
-                        .param("rating", "4.5")
+                        .file(image1)
+                        .file(image2)
+                        .file(image3)
+                        .param("classId", request.classId().toString())
+                        .param("lessonId", request.lessonId().toString())
+                        .param("contents", request.contents()) // 10자 미만
+                        .param("rating", request.rating().toString())
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
@@ -137,17 +154,23 @@ class ReviewControllerTest {
     @DisplayName("리뷰 등록 실패 - 평점 범위 초과")
     void registerReview_fail_rating_out_of_range() throws Exception {
         // Given
-        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
+        User mockUser = User.builder().userId(1L).build();
+        RegisterReviewDto.Request request = new RegisterReviewDto.Request(
+                1L, 1L, "This is a valid content.", 7.0, image1, image2, image3);
+        RegisterReviewDto.Response response = new RegisterReviewDto.Response(1L);
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(mockUser));
+        given(reviewService.registerReview(eq(mockUser), eq(request))).willReturn(response);
 
         // When & Then
         mockMvc.perform(multipart(HttpMethod.POST, "/api/reviews")
-                        .file("image1", image1.getBytes())
-                        .file("image2", image2.getBytes())
-                        .file("image3", image3.getBytes())
-                        .param("classId", "1")
-                        .param("lessonId", "1")
-                        .param("contents", "This is a valid content.")
-                        .param("rating", "5.1") // 5 초과
+                        .file(image1)
+                        .file(image2)
+                        .file(image3)
+                        .param("classId", request.classId().toString())
+                        .param("lessonId", request.lessonId().toString())
+                        .param("contents", request.contents()) // 10자 미만
+                        .param("rating", request.rating().toString())
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
@@ -161,19 +184,23 @@ class ReviewControllerTest {
     @DisplayName("리뷰 등록 실패 - 이미 등록된 리뷰")
     void registerReview_fail_already_register_review() throws Exception {
         // Given
-        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
-        given(reviewService.registerReview(any(User.class), any(RegisterReviewDto.Request.class)))
+        User mockUser = User.builder().userId(1L).build();
+        RegisterReviewDto.Request request = new RegisterReviewDto.Request(1L, 1L,
+                "This is a valid content.", 4.5, image1, image2, image3);
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(mockUser));
+        given(reviewService.registerReview(eq(mockUser), eq(request)))
                 .willThrow(new RestApiException(REVIEW_ALREADY_EXISTS));
 
         // When & Then
         mockMvc.perform(multipart(HttpMethod.POST, "/api/reviews")
-                        .file("image1", image1.getBytes())
-                        .file("image2", image2.getBytes())
-                        .file("image3", image3.getBytes())
-                        .param("classId", "1")
-                        .param("lessonId", "1")
-                        .param("contents", "This is a valid content.")
-                        .param("rating", "4.5") // 5 초과
+                        .file(image1)
+                        .file(image2)
+                        .file(image3)
+                        .param("classId", request.classId().toString())
+                        .param("lessonId", request.lessonId().toString())
+                        .param("contents", request.contents())
+                        .param("rating", request.rating().toString())
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
@@ -187,26 +214,30 @@ class ReviewControllerTest {
     @DisplayName("리뷰 수정 성공")
     void updateReview_success() throws Exception {
         // Given
-        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
-        given(reviewService.updateReview(
-                any(User.class), any(UpdateReviewDto.Request.class), any(Long.class)
-        )).willReturn(new UpdateReviewDto.Response(1L, "updated review contents", 4.5));
+        User mockUser = User.builder().userId(1L).build();
+        UpdateReviewDto.Request request = new UpdateReviewDto.Request(
+                "updated review contents", 4.5, image1, image2, image3);
+        UpdateReviewDto.Response response =
+                new UpdateReviewDto.Response(1L, "updated review contents", 4.5);
+
+        given(userRepository.findById(mockUser.getUserId())).willReturn(Optional.of(mockUser));
+        given(reviewService.updateReview(mockUser, request, 1L)).willReturn(response);
 
         // When & Then
         mockMvc.perform(MockMvcRequestBuilders
                         .multipart(HttpMethod.PUT, "/api/reviews/{reviewId}", 1L)
-                        .file("image1", image1.getBytes())
-                        .file("image2", image2.getBytes())
-                        .file("image3", image3.getBytes())
-                        .param("contents", "updated review contents")
-                        .param("rating", "4.5")
+                        .file(image1)
+                        .file(image2)
+                        .file(image3)
+                        .param("contents", request.contents())
+                        .param("rating", request.rating().toString())
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("SUCCESS"))
-                .andExpect(jsonPath("$.data.reviewId").value(1L))
-                .andExpect(jsonPath("$.data.contents").value("updated review contents"))
-                .andExpect(jsonPath("$.data.rating").value(4.5))
+                .andExpect(jsonPath("$.data.reviewId").value(response.reviewId()))
+                .andExpect(jsonPath("$.data.contents").value(response.contents()))
+                .andExpect(jsonPath("$.data.rating").value(response.rating()))
         ;
     }
 
@@ -214,16 +245,23 @@ class ReviewControllerTest {
     @DisplayName("리뷰 수정 실패 - 리뷰 내용 길이 미달")
     void updateReview_fail_contents_too_short() throws Exception {
         // Given
-        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
+        User mockUser = User.builder().userId(1L).build();
+        UpdateReviewDto.Request request = new UpdateReviewDto.Request(
+                "short", 4.5, image1, image2, image3);
+        UpdateReviewDto.Response response =
+                new UpdateReviewDto.Response(1L, "updated review contents", 4.5);
+
+        given(userRepository.findById(mockUser.getUserId())).willReturn(Optional.of(mockUser));
+        given(reviewService.updateReview(eq(mockUser), eq(request), eq(1L))).willReturn(response);
 
         // When & Then
         mockMvc.perform(MockMvcRequestBuilders
                         .multipart(HttpMethod.PUT, "/api/reviews/{reviewId}", 1L)
-                        .file("image1", image1.getBytes())
-                        .file("image2", image2.getBytes())
-                        .file("image3", image3.getBytes())
-                        .param("contents", "short") // 10자 미만
-                        .param("rating", "4.5")
+                        .file(image1)
+                        .file(image2)
+                        .file(image3)
+                        .param("contents", request.contents())
+                        .param("rating", request.rating().toString())
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
@@ -237,16 +275,23 @@ class ReviewControllerTest {
     @DisplayName("리뷰 수정 실패 - 평점 범위 초과")
     void updateReview_fail_rating_out_of_range() throws Exception {
         // Given
-        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
+        User mockUser = User.builder().userId(1L).build();
+        UpdateReviewDto.Request request = new UpdateReviewDto.Request(
+                "updated review contents", 10.0, image1, image2, image3);
+        UpdateReviewDto.Response response =
+                new UpdateReviewDto.Response(1L, "updated review contents", 4.5);
+
+        given(userRepository.findById(mockUser.getUserId())).willReturn(Optional.of(mockUser));
+        given(reviewService.updateReview(eq(mockUser), eq(request), eq(1L))).willReturn(response);
 
         // When & Then
         mockMvc.perform(MockMvcRequestBuilders
                         .multipart(HttpMethod.PUT, "/api/reviews/{reviewId}", 1L)
-                        .file("image1", image1.getBytes())
-                        .file("image2", image2.getBytes())
-                        .file("image3", image3.getBytes())
-                        .param("contents", "This is a valid content.")
-                        .param("rating", "5.1") // 5 초과
+                        .file(image1)
+                        .file(image2)
+                        .file(image3)
+                        .param("contents", request.contents())
+                        .param("rating", request.rating().toString())
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
@@ -260,19 +305,22 @@ class ReviewControllerTest {
     @DisplayName("리뷰 수정 실패 - 리뷰 작성자가 아닌 사용자")
     void updateReview_fail_not_review_owner() throws Exception {
         // Given
-        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
-        given(reviewService.updateReview(any(User.class), any(UpdateReviewDto.Request.class),
-                any(Long.class))
-        ).willThrow(new RestApiException(NOT_REVIEW_OWNER));
+        User mockUser = User.builder().userId(1L).build();
+        UpdateReviewDto.Request request = new UpdateReviewDto.Request(
+                "updated review contents", 4.5, image1, image2, image3);
+
+        given(userRepository.findById(mockUser.getUserId())).willReturn(Optional.of(mockUser));
+        given(reviewService.updateReview(eq(mockUser), eq(request), eq(1L)))
+                .willThrow(new RestApiException(NOT_REVIEW_OWNER));
 
         // When & Then
         mockMvc.perform(MockMvcRequestBuilders
                         .multipart(HttpMethod.PUT, "/api/reviews/{reviewId}", 1L)
-                        .file("image1", image1.getBytes())
-                        .file("image2", image2.getBytes())
-                        .file("image3", image3.getBytes())
-                        .param("contents", "This is a valid content.")
-                        .param("rating", "4.5")
+                        .file(image1)
+                        .file(image2)
+                        .file(image3)
+                        .param("contents", request.contents())
+                        .param("rating", request.rating().toString())
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
                 .andDo(print())
                 .andExpect(status().isForbidden())
@@ -285,19 +333,22 @@ class ReviewControllerTest {
     @DisplayName("리뷰 수정 실패 - 존재 하지 않는 리뷰 ID")
     void updateReview_fail_not_exist_review_id() throws Exception {
         // Given
-        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
-        given(reviewService.updateReview(any(User.class), any(UpdateReviewDto.Request.class),
-                any(Long.class))
-        ).willThrow(new RestApiException(REVIEW_NOT_FOUND));
+        User mockUser = User.builder().userId(1L).build();
+        UpdateReviewDto.Request request = new UpdateReviewDto.Request(
+                "updated review contents", 4.5, image1, image2, image3);
+
+        given(userRepository.findById(mockUser.getUserId())).willReturn(Optional.of(mockUser));
+        given(reviewService.updateReview(eq(mockUser), eq(request), eq(1L)))
+                .willThrow(new RestApiException(REVIEW_NOT_FOUND));
 
         // When & Then
         mockMvc.perform(MockMvcRequestBuilders
                         .multipart(HttpMethod.PUT, "/api/reviews/{reviewId}", 1L)
-                        .file("image1", image1.getBytes())
-                        .file("image2", image2.getBytes())
-                        .file("image3", image3.getBytes())
-                        .param("contents", "This is a valid content.")
-                        .param("rating", "4.5")
+                        .file(image1)
+                        .file(image2)
+                        .file(image3)
+                        .param("contents", request.contents())
+                        .param("rating", request.rating().toString())
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
@@ -310,9 +361,10 @@ class ReviewControllerTest {
     @DisplayName("리뷰 삭제 성공")
     void deleteReview_success() throws Exception {
         // Given
-        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
-        given(reviewService.deleteReview(any(User.class), any(Long.class))
-        ).willReturn(new DeleteReviewResponse(1L));
+        User mockUser = User.builder().userId(1L).build();
+        given(userRepository.findById(1L)).willReturn(Optional.of(mockUser));
+        given(reviewService.deleteReview(eq(mockUser), eq(1L))).
+                willReturn(new DeleteReviewResponse(1L));
 
         // When & Then
         mockMvc.perform(MockMvcRequestBuilders
@@ -329,9 +381,10 @@ class ReviewControllerTest {
     @DisplayName("리뷰 삭제 실패 - 리뷰 작성자가 아닌 사용자")
     void deleteReview_fail_not_review_owner() throws Exception {
         // Given
-        given(userRepository.findById(1L)).willReturn(Optional.of(new User()));
-        given(reviewService.deleteReview(any(User.class), any(Long.class))
-        ).willThrow(new RestApiException(NOT_REVIEW_OWNER));
+        User mockUser = User.builder().userId(1L).build();
+        given(userRepository.findById(1L)).willReturn(Optional.of(mockUser));
+        given(reviewService.deleteReview(eq(mockUser), eq(1L)))
+                .willThrow(new RestApiException(NOT_REVIEW_OWNER));
 
         // When & Then
         mockMvc.perform(MockMvcRequestBuilders
@@ -371,18 +424,21 @@ class ReviewControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("SUCCESS"))
-                .andExpect(jsonPath("$.data.reviewId").value(1L))
-                .andExpect(jsonPath("$.data.classId").value(1L))
-                .andExpect(jsonPath("$.data.className").value("className"))
-                .andExpect(jsonPath("$.data.lessonId").value(1L))
-                .andExpect(jsonPath("$.data.userId").value(1L))
-                .andExpect(jsonPath("$.data.userNickName").value("userNickName"))
-                .andExpect(jsonPath("$.data.rating").value(4.5))
-                .andExpect(jsonPath("$.data.contents").value("contents"))
+                .andExpect(jsonPath("$.data.reviewId").value(response.reviewId()))
+                .andExpect(jsonPath("$.data.classId").value(response.classId()))
+                .andExpect(jsonPath("$.data.className").value(response.className()))
+                .andExpect(jsonPath("$.data.lessonId").value(response.lessonId()))
+                .andExpect(jsonPath("$.data.userId").value(response.userId()))
+                .andExpect(jsonPath("$.data.userNickName").value(response.userNickName()))
+                .andExpect(jsonPath("$.data.rating").value(response.rating()))
+                .andExpect(jsonPath("$.data.contents").value(response.contents()))
                 .andExpect(jsonPath("$.data.reviewImageUrlList").isArray())
-                .andExpect(jsonPath("$.data.reviewImageUrlList[0]").value("image1"))
-                .andExpect(jsonPath("$.data.reviewImageUrlList[1]").value("image2"))
-                .andExpect(jsonPath("$.data.reviewImageUrlList[2]").value("image3"));
+                .andExpect(jsonPath("$.data.reviewImageUrlList[0]").value(
+                        response.reviewImageUrlList().get(0)))
+                .andExpect(jsonPath("$.data.reviewImageUrlList[1]").value(
+                        response.reviewImageUrlList().get(1)))
+                .andExpect(jsonPath("$.data.reviewImageUrlList[2]").value(
+                        response.reviewImageUrlList().get(2)));
     }
 
     @Test

--- a/src/test/java/com/linked/classbridge/controller/TutorControllerTest.java
+++ b/src/test/java/com/linked/classbridge/controller/TutorControllerTest.java
@@ -1,0 +1,124 @@
+package com.linked.classbridge.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.linked.classbridge.domain.User;
+import com.linked.classbridge.dto.review.GetReviewResponse;
+import com.linked.classbridge.repository.UserRepository;
+import com.linked.classbridge.service.ReviewService;
+import com.linked.classbridge.type.ResponseMessage;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(TutorController.class)
+@TestPropertySource(properties = "spring.config.location=classpath:application-test.yml")
+class TutorControllerTest {
+
+    @MockBean
+    private ReviewService reviewService;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private Pageable pageable;
+
+    private User mockTutor1;
+    private GetReviewResponse reviewResponse1;
+    private GetReviewResponse reviewResponse2;
+    private GetReviewResponse reviewResponse3;
+    private GetReviewResponse reviewResponse4;
+
+    @BeforeEach
+    void setUp() {
+        mockTutor1 = User.builder()
+                .userId(1L)
+                .nickname("tutorNickname")
+                .build();
+
+        pageable = PageRequest.of(0, 5, Direction.DESC, "createdAt");
+
+        reviewResponse1 = new GetReviewResponse(
+                1L, 1L, "className", 1L, 1L,
+                "userNickname", 4.5, "review1 content",
+                LocalDateTime.now(), LocalDateTime.now(), List.of("url1", "url2", "url3")
+        );
+        reviewResponse2 = new GetReviewResponse(
+                1L, 1L, "className", 2L, 1L,
+                "userNickname", 4.5, "review1 content",
+                LocalDateTime.now(), LocalDateTime.now(), List.of("url1", "url2", "url3")
+        );
+        reviewResponse3 = new GetReviewResponse(
+                1L, 2L, "className", 3L, 2L,
+                "userNickname", 4.5, "review1 content",
+                LocalDateTime.now(), LocalDateTime.now(), List.of("url1", "url2", "url3")
+        );
+        reviewResponse4 = new GetReviewResponse(
+                1L, 2L, "className", 4L, 2L,
+                "userNickname", 4.5, "review1 content",
+                LocalDateTime.now(), LocalDateTime.now(), List.of("url1", "url2", "url3")
+        );
+    }
+
+    @Test
+    @DisplayName("강사 받은 리뷰 목록 조회")
+    void getUserReviews() throws Exception {
+        // given
+        given(userRepository.findById(1L)).willReturn(Optional.of(mockTutor1));
+        given(reviewService.getTutorReviews(mockTutor1, pageable)).willReturn(new SliceImpl<>(
+                Arrays.asList(reviewResponse1, reviewResponse2, reviewResponse3, reviewResponse4)
+                , pageable, true)
+        );
+
+        // when & then
+        mockMvc.perform(get("/api/tutors/reviews")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("page", "0")
+                        .param("size", "5")
+                        .param("sort", "createdAt,desc")
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.message").value(
+                        ResponseMessage.REVIEW_GET_SUCCESS.getMessage()))
+                .andExpect(jsonPath("$.data.content[0].reviewId").value(reviewResponse1.reviewId()))
+                .andExpect(jsonPath("$.data.content[0].classId").value(reviewResponse1.classId()))
+                .andExpect(jsonPath("$.data.content[0].lessonId").value(reviewResponse1.lessonId()))
+                .andExpect(jsonPath("$.data.content[0].userId").value(reviewResponse1.userId()))
+                .andExpect(jsonPath("$.data.content[1].reviewId").value(reviewResponse2.reviewId()))
+                .andExpect(jsonPath("$.data.content[1].classId").value(reviewResponse2.classId()))
+                .andExpect(jsonPath("$.data.content[1].lessonId").value(reviewResponse2.lessonId()))
+                .andExpect(jsonPath("$.data.content[1].userId").value(reviewResponse2.userId()))
+                .andExpect(jsonPath("$.data.content[2].reviewId").value(reviewResponse3.reviewId()))
+                .andExpect(jsonPath("$.data.content[2].classId").value(reviewResponse3.classId()))
+                .andExpect(jsonPath("$.data.content[2].lessonId").value(reviewResponse3.lessonId()))
+                .andExpect(jsonPath("$.data.content[2].userId").value(reviewResponse3.userId()))
+                .andExpect(jsonPath("$.data.content[3].reviewId").value(reviewResponse4.reviewId()))
+                .andExpect(jsonPath("$.data.content[3].classId").value(reviewResponse4.classId()))
+                .andExpect(jsonPath("$.data.content[3].lessonId").value(reviewResponse4.lessonId()))
+                .andExpect(jsonPath("$.data.content[3].userId").value(reviewResponse4.userId()));
+    }
+
+}

--- a/src/test/java/com/linked/classbridge/controller/TutorControllerTest.java
+++ b/src/test/java/com/linked/classbridge/controller/TutorControllerTest.java
@@ -21,9 +21,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
@@ -86,9 +86,9 @@ class TutorControllerTest {
     void getUserReviews() throws Exception {
         // given
         given(userRepository.findById(1L)).willReturn(Optional.of(mockTutor1));
-        given(reviewService.getTutorReviews(mockTutor1, pageable)).willReturn(new SliceImpl<>(
+        given(reviewService.getTutorReviews(mockTutor1, pageable)).willReturn(new PageImpl<>(
                 Arrays.asList(reviewResponse1, reviewResponse2, reviewResponse3, reviewResponse4)
-                , pageable, true)
+                , pageable, 4)
         );
 
         // when & then

--- a/src/test/java/com/linked/classbridge/controller/UserControllerTest.java
+++ b/src/test/java/com/linked/classbridge/controller/UserControllerTest.java
@@ -1,0 +1,133 @@
+package com.linked.classbridge.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.linked.classbridge.domain.User;
+import com.linked.classbridge.dto.review.GetReviewResponse;
+import com.linked.classbridge.repository.UserRepository;
+import com.linked.classbridge.service.ReviewService;
+import com.linked.classbridge.type.ResponseMessage;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+
+@WebMvcTest(UserController.class)
+@TestPropertySource(properties = "spring.config.location=classpath:application-test.yml")
+class UserControllerTest {
+
+    @MockBean
+    private ReviewService reviewService;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private Pageable pageable;
+
+    private User mockUser;
+    private GetReviewResponse reviewResponse1;
+    private GetReviewResponse reviewResponse2;
+
+    private GetReviewResponse reviewResponse3;
+    private GetReviewResponse reviewResponse4;
+
+    @BeforeEach
+    void setUp() {
+        mockUser = User.builder()
+                .userId(1L)
+                .nickname("userNickname")
+                .build();
+
+        pageable = PageRequest.of(0, 5, Direction.DESC, "createdAt");
+
+        reviewResponse1 = new GetReviewResponse(
+                1L, 1L, "className", 1L, 1L,
+                "userNickname", 4.5, "review1 content",
+                LocalDateTime.of(2024, 6, 1, 9, 0),
+                LocalDateTime.of(2024, 6, 3, 15, 0),
+                List.of("url1", "url2", "url3")
+        );
+        reviewResponse2 = new GetReviewResponse(
+                2L, 1L, "className", 2L, 1L,
+                "userNickname", 2.3, "review2 content",
+                LocalDateTime.of(2024, 6, 1, 12, 0),
+                LocalDateTime.of(2024, 6, 2, 17, 0),
+                List.of("url4", "url5", "url6")
+        );
+        reviewResponse3 = new GetReviewResponse(
+                3L, 2L, "className", 3L, 1L,
+                "userNickname", 3.7, "review3 content",
+                LocalDateTime.of(2024, 6, 1, 15, 0),
+                LocalDateTime.of(2024, 6, 1, 20, 0),
+                List.of("url7", "url8", "url9")
+        );
+        reviewResponse4 = new GetReviewResponse(
+                4L, 2L, "className", 4L, 1L,
+                "userNickname", 5.0, "review4 content",
+                LocalDateTime.of(2024, 6, 1, 18, 0),
+                LocalDateTime.of(2024, 6, 1, 23, 0),
+                List.of("url10", "url11", "url12")
+        );
+    }
+
+    @Test
+    @DisplayName("유저 리뷰 목록 조회")
+    void getUserReviews() throws Exception {
+        // given
+        given(userRepository.findById(1L)).willReturn(Optional.of(mockUser));
+        given(reviewService.getUserReviews(mockUser, pageable)).willReturn(new SliceImpl<>(
+                Arrays.asList(reviewResponse1, reviewResponse2, reviewResponse3, reviewResponse4)
+                , pageable, true)
+        );
+
+        // when & then
+        mockMvc.perform(get("/api/users/reviews")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("page", "0")
+                        .param("size", "5")
+                        .param("sort", "createdAt,desc")
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.message").value(
+                        ResponseMessage.REVIEW_GET_SUCCESS.getMessage()))
+                .andExpect(jsonPath("$.data.content[0].reviewId").value(reviewResponse1.reviewId()))
+                .andExpect(jsonPath("$.data.content[0].classId").value(reviewResponse1.classId()))
+                .andExpect(jsonPath("$.data.content[0].lessonId").value(reviewResponse1.lessonId()))
+                .andExpect(jsonPath("$.data.content[0].userId").value(reviewResponse1.userId()))
+                .andExpect(jsonPath("$.data.content[1].reviewId").value(reviewResponse2.reviewId()))
+                .andExpect(jsonPath("$.data.content[1].classId").value(reviewResponse2.classId()))
+                .andExpect(jsonPath("$.data.content[1].lessonId").value(reviewResponse2.lessonId()))
+                .andExpect(jsonPath("$.data.content[1].userId").value(reviewResponse2.userId()))
+                .andExpect(jsonPath("$.data.content[2].reviewId").value(reviewResponse3.reviewId()))
+                .andExpect(jsonPath("$.data.content[2].classId").value(reviewResponse3.classId()))
+                .andExpect(jsonPath("$.data.content[2].lessonId").value(reviewResponse3.lessonId()))
+                .andExpect(jsonPath("$.data.content[2].userId").value(reviewResponse3.userId()))
+                .andExpect(jsonPath("$.data.content[3].reviewId").value(reviewResponse4.reviewId()))
+                .andExpect(jsonPath("$.data.content[3].classId").value(reviewResponse4.classId()))
+                .andExpect(jsonPath("$.data.content[3].lessonId").value(reviewResponse4.lessonId()))
+                .andExpect(jsonPath("$.data.content[3].userId").value(reviewResponse4.userId()));
+    }
+}

--- a/src/test/java/com/linked/classbridge/controller/UserControllerTest.java
+++ b/src/test/java/com/linked/classbridge/controller/UserControllerTest.java
@@ -21,9 +21,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
@@ -96,9 +96,9 @@ class UserControllerTest {
     void getUserReviews() throws Exception {
         // given
         given(userRepository.findById(1L)).willReturn(Optional.of(mockUser));
-        given(reviewService.getUserReviews(mockUser, pageable)).willReturn(new SliceImpl<>(
+        given(reviewService.getUserReviews(mockUser, pageable)).willReturn(new PageImpl<>(
                 Arrays.asList(reviewResponse1, reviewResponse2, reviewResponse3, reviewResponse4)
-                , pageable, true)
+                , pageable, 4)
         );
 
         // when & then

--- a/src/test/java/com/linked/classbridge/service/ReviewServiceTest.java
+++ b/src/test/java/com/linked/classbridge/service/ReviewServiceTest.java
@@ -1,0 +1,123 @@
+package com.linked.classbridge.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import com.linked.classbridge.domain.Lesson;
+import com.linked.classbridge.domain.OneDayClass;
+import com.linked.classbridge.domain.Review;
+import com.linked.classbridge.domain.ReviewImage;
+import com.linked.classbridge.domain.User;
+import com.linked.classbridge.dto.review.GetReviewResponse;
+import com.linked.classbridge.repository.ReviewImageRepository;
+import com.linked.classbridge.repository.ReviewRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceTest {
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @Mock
+    private ReviewImageRepository reviewImageRepository;
+
+    @Mock
+    private LessonService lessonService;
+
+    @Mock
+    private S3Service s3Service;
+
+    @InjectMocks
+    private ReviewService reviewService;
+
+    @Test
+    @DisplayName("리뷰 조회 성공")
+    void getReview_success() {
+        // given
+        Review review = createMockReview();
+
+        given(reviewRepository.findById(anyLong())).willReturn(Optional.of(review));
+
+        // when
+        GetReviewResponse response = reviewService.getReview(1L);
+
+        // then
+        assertNotNull(response);
+        assertEquals(response.reviewId(), review.getReviewId());
+        assertEquals(response.classId(), review.getOneDayClass().getOneDayClassId());
+        assertEquals(response.className(), review.getOneDayClass().getClassName());
+        assertEquals(response.lessonId(), review.getLesson().getLessonId());
+        assertEquals(response.userId(), review.getUser().getUserId());
+        assertEquals(response.userNickName(), review.getUser().getNickname());
+        assertEquals(response.rating(), review.getRating());
+        assertEquals(response.contents(), review.getContents());
+        assertEquals(response.lessonDate(), review.getLesson().getLessonDate());
+        assertEquals(response.createdAt(), review.getCreatedAt());
+        assertThat(response.reviewImageUrlList()).containsExactly("url1", "url2", "url3");
+    }
+
+
+    private Review createMockReview() {
+        OneDayClass oneDayClass = OneDayClass.builder()
+                .oneDayClassId(1L)
+                .className("oneDayClassName")
+                .build();
+
+        Lesson lesson = Lesson.builder()
+                .lessonId(1L)
+                .oneDayClass(oneDayClass)
+                .lessonDate(LocalDateTime.now())
+                .build();
+
+        User user = User.builder()
+                .userId(1L)
+                .nickname("user")
+                .build();
+
+        Review review = Review.builder()
+                .reviewId(1L)
+                .oneDayClass(oneDayClass)
+                .lesson(lesson)
+                .user(user)
+                .rating(5.0)
+                .contents("contents")
+                .createdAt(LocalDateTime.now())
+                .reviewImageList(new ArrayList<>())
+                .build();
+
+        ReviewImage image1 = ReviewImage.builder()
+                .review(review)
+                .sequence(1)
+                .url("url1")
+                .build();
+        review.addReviewImage(image1);
+
+        ReviewImage image2 = ReviewImage.builder()
+                .review(review)
+                .sequence(2)
+                .url("url2")
+                .build();
+        review.addReviewImage(image2);
+
+        ReviewImage image3 = ReviewImage.builder()
+                .review(review)
+                .sequence(3)
+                .url("url3")
+                .build();
+        review.addReviewImage(image3);
+
+        return review;
+    }
+}

--- a/src/test/java/com/linked/classbridge/service/ReviewServiceTest.java
+++ b/src/test/java/com/linked/classbridge/service/ReviewServiceTest.java
@@ -40,9 +40,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
@@ -529,15 +529,15 @@ class ReviewServiceTest {
         // given
         Pageable pageable = mock(Pageable.class);
 
-        Slice<Review> reviewSlice =
-                new SliceImpl<>(Arrays.asList(mockReview1, mockReview2), pageable, true);
+        Page<Review> reviewPage =
+                new PageImpl<>(Arrays.asList(mockReview1, mockReview2), pageable, 2);
 
         given(oneDayClassService.findClassById(1L)).willReturn(mockOneDayClass1);
         given(reviewRepository.findByOneDayClass(mockOneDayClass1, pageable))
-                .willReturn(reviewSlice);
+                .willReturn(reviewPage);
 
         // when
-        Slice<GetReviewResponse> responses = reviewService.getClassReviews(1L, pageable);
+        Page<GetReviewResponse> responses = reviewService.getClassReviews(1L, pageable);
 
         // then
         assertThat(responses).hasSize(2);
@@ -584,13 +584,13 @@ class ReviewServiceTest {
         // given
         Pageable pageable = mock(Pageable.class);
 
-        Slice<Review> reviewSlice =
-                new SliceImpl<>(Arrays.asList(mockReview1, mockReview3), pageable, true);
+        Page<Review> reviewPage =
+                new PageImpl<>(Arrays.asList(mockReview1, mockReview3), pageable, 2);
 
-        given(reviewRepository.findByUser(mockUser1, pageable)).willReturn(reviewSlice);
+        given(reviewRepository.findByUser(mockUser1, pageable)).willReturn(reviewPage);
 
         // when
-        Slice<GetReviewResponse> responses = reviewService.getUserReviews(mockUser1, pageable);
+        Page<GetReviewResponse> responses = reviewService.getUserReviews(mockUser1, pageable);
 
         // then
         assertThat(responses).hasSize(2);
@@ -620,14 +620,14 @@ class ReviewServiceTest {
         // given
         Pageable pageable = mock(Pageable.class);
 
-        Slice<Review> reviewSlice =
-                new SliceImpl<>(Arrays.asList(mockReview1, mockReview2, mockReview3, mockReview4),
-                        pageable, true);
+        Page<Review> reviewPage =
+                new PageImpl<>(Arrays.asList(mockReview1, mockReview2, mockReview3, mockReview4),
+                        pageable, 4);
 
-        given(reviewRepository.findByTutor(tutor, pageable)).willReturn(reviewSlice);
+        given(reviewRepository.findByTutor(tutor, pageable)).willReturn(reviewPage);
 
         // when
-        Slice<GetReviewResponse> responses = reviewService.getTutorReviews(tutor, pageable);
+        Page<GetReviewResponse> responses = reviewService.getTutorReviews(tutor, pageable);
 
         // then
         assertThat(responses).hasSize(4);

--- a/src/test/java/com/linked/classbridge/service/ReviewServiceTest.java
+++ b/src/test/java/com/linked/classbridge/service/ReviewServiceTest.java
@@ -613,4 +613,50 @@ class ReviewServiceTest {
         assertThat(responses).extracting("lessonDate")
                 .containsExactly(mockLesson1.getLessonDate(), mockLesson2.getLessonDate());
     }
+
+    @Test
+    @DisplayName("강사 받은 리뷰 목록 조회 성공")
+    void getTutorReviews_success() {
+        // given
+        Pageable pageable = mock(Pageable.class);
+
+        Slice<Review> reviewSlice =
+                new SliceImpl<>(Arrays.asList(mockReview1, mockReview2, mockReview3, mockReview4),
+                        pageable, true);
+
+        given(reviewRepository.findByTutor(tutor, pageable)).willReturn(reviewSlice);
+
+        // when
+        Slice<GetReviewResponse> responses = reviewService.getTutorReviews(tutor, pageable);
+
+        // then
+        assertThat(responses).hasSize(4);
+        assertThat(responses).extracting("reviewId").containsExactly(
+                mockReview1.getReviewId(), mockReview2.getReviewId(),
+                mockReview3.getReviewId(), mockReview4.getReviewId());
+        assertThat(responses).extracting("classId").containsExactly(
+                mockOneDayClass1.getOneDayClassId(), mockOneDayClass1.getOneDayClassId(),
+                mockOneDayClass2.getOneDayClassId(), mockOneDayClass2.getOneDayClassId());
+        assertThat(responses).extracting("className").containsExactly(
+                mockOneDayClass1.getClassName(), mockOneDayClass1.getClassName(),
+                mockOneDayClass2.getClassName(), mockOneDayClass2.getClassName());
+        assertThat(responses).extracting("lessonId").containsExactly(
+                mockLesson1.getLessonId(), mockLesson1.getLessonId()
+                , mockLesson2.getLessonId(), mockLesson2.getLessonId());
+        assertThat(responses).extracting("userId").containsExactly(
+                mockUser1.getUserId(), mockUser2.getUserId(),
+                mockUser1.getUserId(), mockUser2.getUserId());
+        assertThat(responses).extracting("userNickName").containsExactly(
+                mockUser1.getNickname(), mockUser2.getNickname(),
+                mockUser1.getNickname(), mockUser2.getNickname());
+        assertThat(responses).extracting("rating").containsExactly(
+                mockReview1.getRating(), mockReview2.getRating(),
+                mockReview3.getRating(), mockReview4.getRating());
+        assertThat(responses).extracting("contents").containsExactly(
+                mockReview1.getContents(), mockReview2.getContents(),
+                mockReview3.getContents(), mockReview4.getContents());
+        assertThat(responses).extracting("lessonDate").containsExactly(
+                mockLesson1.getLessonDate(), mockLesson1.getLessonDate(),
+                mockLesson2.getLessonDate(), mockLesson2.getLessonDate());
+    }
 }

--- a/src/test/java/com/linked/classbridge/service/ReviewServiceTest.java
+++ b/src/test/java/com/linked/classbridge/service/ReviewServiceTest.java
@@ -68,11 +68,15 @@ class ReviewServiceTest {
     private User mockUser1;
     private User mockUser2;
     private User tutor;
-    private Lesson mockLesson;
-    private OneDayClass mockOneDayClass;
+    private Lesson mockLesson1;
+    private Lesson mockLesson2;
+    private OneDayClass mockOneDayClass1;
+    private OneDayClass mockOneDayClass2;
 
     private Review mockReview1;
     private Review mockReview2;
+    private Review mockReview3;
+    private Review mockReview4;
 
     private ReviewImage mockReviewImage1;
     private ReviewImage mockReviewImage2;
@@ -100,7 +104,7 @@ class ReviewServiceTest {
                 .reviewList(new ArrayList<>())
                 .build();
 
-        mockOneDayClass = OneDayClass.builder()
+        mockOneDayClass1 = OneDayClass.builder()
                 .oneDayClassId(1L)
                 .tutor(tutor)
                 .className("oneDayClassName")
@@ -108,17 +112,31 @@ class ReviewServiceTest {
                 .totalStarRate(0.0)
                 .totalReviews(0)
                 .build();
-        mockLesson = Lesson.builder()
+        mockOneDayClass2 = OneDayClass.builder()
+                .oneDayClassId(2L)
+                .tutor(tutor)
+                .className("oneDayClassName2")
+                .reviewList(new ArrayList<>())
+                .totalStarRate(0.0)
+                .totalReviews(0)
+                .build();
+        mockLesson1 = Lesson.builder()
                 .lessonId(1L)
-                .oneDayClass(mockOneDayClass)
+                .oneDayClass(mockOneDayClass1)
+                .lessonDate(LocalDateTime.now())
+                .reviewList(new ArrayList<>())
+                .build();
+        mockLesson2 = Lesson.builder()
+                .lessonId(2L)
+                .oneDayClass(mockOneDayClass2)
                 .lessonDate(LocalDateTime.now())
                 .reviewList(new ArrayList<>())
                 .build();
         mockReview1 = Review.builder()
                 .reviewId(1L)
                 .user(mockUser1)
-                .lesson(mockLesson)
-                .oneDayClass(mockOneDayClass)
+                .lesson(mockLesson1)
+                .oneDayClass(mockOneDayClass1)
                 .contents("review1 contents")
                 .rating(4.5)
                 .createdAt(LocalDateTime.now())
@@ -127,10 +145,30 @@ class ReviewServiceTest {
         mockReview2 = Review.builder()
                 .reviewId(2L)
                 .user(mockUser2)
-                .lesson(mockLesson)
-                .oneDayClass(mockOneDayClass)
+                .lesson(mockLesson1)
+                .oneDayClass(mockOneDayClass1)
                 .contents("review2 contents")
                 .rating(3.5)
+                .createdAt(LocalDateTime.now())
+                .reviewImageList(new ArrayList<>())
+                .build();
+        mockReview3 = Review.builder()
+                .reviewId(3L)
+                .user(mockUser1)
+                .lesson(mockLesson2)
+                .oneDayClass(mockOneDayClass2)
+                .contents("review3 contents")
+                .rating(2.5)
+                .createdAt(LocalDateTime.now())
+                .reviewImageList(new ArrayList<>())
+                .build();
+        mockReview4 = Review.builder()
+                .reviewId(4L)
+                .user(mockUser2)
+                .lesson(mockLesson2)
+                .oneDayClass(mockOneDayClass2)
+                .contents("review4 contents")
+                .rating(1.5)
                 .createdAt(LocalDateTime.now())
                 .reviewImageList(new ArrayList<>())
                 .build();
@@ -171,11 +209,17 @@ class ReviewServiceTest {
                 .sequence(3)
                 .build();
         mockUser1.addReview(mockReview1);
+        mockUser1.addReview(mockReview3);
         mockUser2.addReview(mockReview2);
-        mockLesson.addReview(mockReview1);
-        mockLesson.addReview(mockReview2);
-        mockOneDayClass.addReview(mockReview1);
-        mockOneDayClass.addReview(mockReview2);
+        mockUser2.addReview(mockReview4);
+        mockLesson1.addReview(mockReview1);
+        mockLesson1.addReview(mockReview2);
+        mockLesson2.addReview(mockReview3);
+        mockLesson2.addReview(mockReview4);
+        mockOneDayClass1.addReview(mockReview1);
+        mockOneDayClass1.addReview(mockReview2);
+        mockOneDayClass2.addReview(mockReview3);
+        mockOneDayClass2.addReview(mockReview4);
         mockReview1.addReviewImage(mockReviewImage1);
         mockReview1.addReviewImage(mockReviewImage2);
         mockReview1.addReviewImage(mockReviewImage3);
@@ -189,7 +233,7 @@ class ReviewServiceTest {
         MultipartFile image2 = mock(MultipartFile.class);
         MultipartFile image3 = mock(MultipartFile.class);
         return new RegisterReviewDto.Request(
-                mockLesson.getLessonId(), mockOneDayClass.getOneDayClassId(),
+                mockLesson1.getLessonId(), mockOneDayClass1.getOneDayClassId(),
                 mockReview1.getContents(), mockReview1.getRating(), image1, image2, image3);
     }
 
@@ -252,13 +296,13 @@ class ReviewServiceTest {
 
         RegisterReviewDto.Request request = createRegisterReviewDtoRequest();
 
-        Review reviewToSave = RegisterReviewDto.Request.toEntity(mockUser1, mockLesson,
-                mockOneDayClass, request);
+        Review reviewToSave = RegisterReviewDto.Request.toEntity(mockUser1, mockLesson1,
+                mockOneDayClass1, request);
         Review savedReview = mockReview1;
 
-        given(reviewRepository.findByLessonAndUser(mockLesson, mockUser1))
+        given(reviewRepository.findByLessonAndUser(mockLesson1, mockUser1))
                 .willReturn(Optional.empty());
-        given(lessonService.findLessonById(1L)).willReturn(mockLesson);
+        given(lessonService.findLessonById(1L)).willReturn(mockLesson1);
         given(s3Service.uploadReviewImage(request.image1())).willReturn(url1);
         given(s3Service.uploadReviewImage(request.image2())).willReturn(url2);
         given(s3Service.uploadReviewImage(request.image3())).willReturn(url3);
@@ -289,8 +333,8 @@ class ReviewServiceTest {
         // given
         RegisterReviewDto.Request request = createRegisterReviewDtoRequest();
 
-        given(lessonService.findLessonById(request.lessonId())).willReturn(mockLesson);
-        given(reviewRepository.findByLessonAndUser(mockLesson, mockUser1))
+        given(lessonService.findLessonById(request.lessonId())).willReturn(mockLesson1);
+        given(reviewRepository.findByLessonAndUser(mockLesson1, mockUser1))
                 .willReturn(Optional.of(Review.builder().reviewId(1L).build()));
 
         // when
@@ -337,16 +381,16 @@ class ReviewServiceTest {
         // given
         RegisterReviewDto.Request request = createRegisterReviewDtoRequest();
 
-        mockOneDayClass = OneDayClass.builder()
+        mockOneDayClass1 = OneDayClass.builder()
                 .oneDayClassId(2L)
                 .build();
-        mockLesson = Lesson.builder()
+        mockLesson1 = Lesson.builder()
                 .lessonId(1L)
-                .oneDayClass(mockOneDayClass)
+                .oneDayClass(mockOneDayClass1)
                 .build();
 
         given(lessonService.findLessonById(request.lessonId()))
-                .willReturn(mockLesson);
+                .willReturn(mockLesson1);
 
         // when
         RestApiException exception = assertThrows(RestApiException.class,
@@ -488,8 +532,8 @@ class ReviewServiceTest {
         Slice<Review> reviewSlice =
                 new SliceImpl<>(Arrays.asList(mockReview1, mockReview2), pageable, true);
 
-        given(oneDayClassService.findClassById(1L)).willReturn(mockOneDayClass);
-        given(reviewRepository.findByOneDayClass(mockOneDayClass, pageable))
+        given(oneDayClassService.findClassById(1L)).willReturn(mockOneDayClass1);
+        given(reviewRepository.findByOneDayClass(mockOneDayClass1, pageable))
                 .willReturn(reviewSlice);
 
         // when
@@ -500,11 +544,11 @@ class ReviewServiceTest {
         assertThat(responses).extracting("reviewId").containsExactly(
                 mockReview1.getReviewId(), mockReview2.getReviewId());
         assertThat(responses).extracting("classId").containsExactly(
-                mockOneDayClass.getOneDayClassId(), mockOneDayClass.getOneDayClassId());
+                mockOneDayClass1.getOneDayClassId(), mockOneDayClass1.getOneDayClassId());
         assertThat(responses).extracting("className").containsExactly(
-                mockOneDayClass.getClassName(), mockOneDayClass.getClassName());
+                mockOneDayClass1.getClassName(), mockOneDayClass1.getClassName());
         assertThat(responses).extracting("lessonId").containsExactly(
-                mockLesson.getLessonId(), mockLesson.getLessonId());
+                mockLesson1.getLessonId(), mockLesson1.getLessonId());
         assertThat(responses).extracting("userId").containsExactly(
                 mockUser1.getUserId(), mockUser2.getUserId());
         assertThat(responses).extracting("userNickName").containsExactly(
@@ -514,7 +558,7 @@ class ReviewServiceTest {
         assertThat(responses).extracting("contents").containsExactly(
                 mockReview1.getContents(), mockReview2.getContents());
         assertThat(responses).extracting("lessonDate")
-                .containsExactly(mockLesson.getLessonDate(), mockLesson.getLessonDate());
+                .containsExactly(mockLesson1.getLessonDate(), mockLesson1.getLessonDate());
     }
 
     @Test
@@ -532,5 +576,41 @@ class ReviewServiceTest {
 
         // then
         assertEquals(CLASS_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("유저 리뷰 목록 조회 성공")
+    void getUserReviews_success() {
+        // given
+        Pageable pageable = mock(Pageable.class);
+
+        Slice<Review> reviewSlice =
+                new SliceImpl<>(Arrays.asList(mockReview1, mockReview3), pageable, true);
+
+        given(reviewRepository.findByUser(mockUser1, pageable)).willReturn(reviewSlice);
+
+        // when
+        Slice<GetReviewResponse> responses = reviewService.getUserReviews(mockUser1, pageable);
+
+        // then
+        assertThat(responses).hasSize(2);
+        assertThat(responses).extracting("reviewId").containsExactly(
+                mockReview1.getReviewId(), mockReview3.getReviewId());
+        assertThat(responses).extracting("classId").containsExactly(
+                mockOneDayClass1.getOneDayClassId(), mockOneDayClass2.getOneDayClassId());
+        assertThat(responses).extracting("className").containsExactly(
+                mockOneDayClass1.getClassName(), mockOneDayClass2.getClassName());
+        assertThat(responses).extracting("lessonId").containsExactly(
+                mockLesson1.getLessonId(), mockLesson2.getLessonId());
+        assertThat(responses).extracting("userId").containsExactly(
+                mockUser1.getUserId(), mockUser1.getUserId());
+        assertThat(responses).extracting("userNickName").containsExactly(
+                mockUser1.getNickname(), mockUser1.getNickname());
+        assertThat(responses).extracting("rating").containsExactly(
+                mockReview1.getRating(), mockReview3.getRating());
+        assertThat(responses).extracting("contents").containsExactly(
+                mockReview1.getContents(), mockReview3.getContents());
+        assertThat(responses).extracting("lessonDate")
+                .containsExactly(mockLesson1.getLessonDate(), mockLesson2.getLessonDate());
     }
 }


### PR DESCRIPTION
### 변경사항

- 리뷰 상세 조회 기능 추가
- 클래스 별 리뷰 조회 기능 추가
- 강사가 받은 리뷰 조회 기능 추가
- 수강생이 작성한 리뷰 조회 기능 추가
- 멘토님 피드백 반영 (와일드 카드 타입, any() 사용 관련)
- 테스트 코드 작성

**AS-IS**

- ResponseEntity의 와일드 카드 타입 사용
![image](https://github.com/ClassBridge/ClassBridge-BE/assets/152583754/e040968a-ea03-49ab-b1e8-d0dbb605f012)

- 테스트 코드에 ArgumentMatchers any() 사용
![image](https://github.com/ClassBridge/ClassBridge-BE/assets/152583754/29f5907b-65b2-4c1c-81e4-bc35b083bdf0)

**TO-BE**

- ResponseEntity의 타입을 와일드 카드가 아닌 response dto의 타입으로 바꾸어 주었습니다.
![image](https://github.com/ClassBridge/ClassBridge-BE/assets/152583754/a48cda8d-c92f-4222-b96a-0cbb1629fa94)

- 테스트 코드에 any()가 아니라 eq()를 사용하여 고정된 인자를 넣어주었습니다.
![image](https://github.com/ClassBridge/ClassBridge-BE/assets/152583754/1b4e9301-22e0-4263-8ac6-1b5ed975b471)

- 리뷰 조회 api 추가
**GET /api/reviews/{reviewId}**
**GET /api//class/{classId}/reviews**
**GET /api/users/reviews**
**GET /api/tutors/reviews**

- 추가한 각 기능별 테스트 코드 작성
![image](https://github.com/ClassBridge/ClassBridge-BE/assets/152583754/d0fd3577-2151-4e90-a313-5695abcf9447)

- 컨트롤러에서 Slice 객체가 아닌 PagedModel 객체를 반환하도록 하였습니다.
자세한 내용은 아래의 문서를 참조바랍니다.
https://fern-nyala-e74.notion.site/Backend-Page-PlainPageSerializationWarning-warning-d6805097473841828a09d338506f6746?pvs=4

### 테스트

- [x] 테스트 코드
- [x] API 테스트 