### PR TITLE
fix(review) : fix update review image logic

### DIFF
--- a/src/main/java/com/linked/classbridge/config/SecurityConfig.java
+++ b/src/main/java/com/linked/classbridge/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.Collections;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -98,6 +99,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/users/badges/**").permitAll()
                         .requestMatchers("/api/openapi/**").permitAll()
                         .requestMatchers("/api/class/recommend/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/reviews/**").permitAll()
                         .requestMatchers("/api/users").hasRole("USER")
                         .requestMatchers("/api/users/**").hasRole("USER")
                         .anyRequest().authenticated())

--- a/src/main/java/com/linked/classbridge/controller/ReviewController.java
+++ b/src/main/java/com/linked/classbridge/controller/ReviewController.java
@@ -17,11 +17,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
 
 @Controller
 @RequiredArgsConstructor
@@ -34,14 +35,15 @@ public class ReviewController {
     @Operation(summary = "리뷰 등록", description = "리뷰 등록")
     @PostMapping
     public ResponseEntity<SuccessResponse<RegisterReviewDto.Response>> registerReview(
-            @Valid @ModelAttribute RegisterReviewDto.Request request
+            @RequestPart(value = "request") @Valid RegisterReviewDto.Request request,
+            @RequestPart(value = "reviewImages", required = false) MultipartFile[] reviewImages
     ) {
         User user = userService.getUserByEmail(userService.getCurrentUserEmail());
 
         return ResponseEntity.status(HttpStatus.CREATED).body(
                 SuccessResponse.of(
                         ResponseMessage.REVIEW_REGISTER_SUCCESS,
-                        reviewService.registerReview(user, request)
+                        reviewService.registerReview(user, request, reviewImages)
                 )
         );
     }
@@ -49,10 +51,13 @@ public class ReviewController {
     @Operation(summary = "리뷰 수정", description = "리뷰 수정")
     @PutMapping("/{reviewId}")
     public ResponseEntity<SuccessResponse<UpdateReviewDto.Response>> updateReview(
-            @Valid @ModelAttribute UpdateReviewDto.Request request,
+            @RequestPart @Valid UpdateReviewDto.Request request,
+            @RequestPart(value = "reviewImages", required = false) MultipartFile[] reviewImages,
             @PathVariable Long reviewId
     ) {
         User user = userService.getUserByEmail(userService.getCurrentUserEmail());
+
+        reviewService.updateReviewImages(user, reviewId, request.updateReviewImageRequest(), reviewImages);
 
         return ResponseEntity.status(HttpStatus.OK).body(
                 SuccessResponse.of(

--- a/src/main/java/com/linked/classbridge/domain/Lesson.java
+++ b/src/main/java/com/linked/classbridge/domain/Lesson.java
@@ -12,11 +12,12 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.Version;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -56,7 +57,8 @@ public class Lesson extends BaseEntity {
     private OneDayClass oneDayClass;
 
     @OneToMany(mappedBy = "lesson", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private List<Review> reviewList;
+    @Builder.Default
+    private List<Review> reviewList = new ArrayList<>();
 
 //    @Version
 //    private Long version;

--- a/src/main/java/com/linked/classbridge/domain/OneDayClass.java
+++ b/src/main/java/com/linked/classbridge/domain/OneDayClass.java
@@ -15,6 +15,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.Min;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -103,7 +104,8 @@ public class OneDayClass extends BaseEntity {
     private List<Lesson> lessonList;
 
     @OneToMany(mappedBy = "oneDayClass", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private List<Review> reviewList;
+    @Builder.Default
+    private List<Review> reviewList = new ArrayList<>();
 
     @OneToMany(mappedBy = "oneDayClass", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<ClassFAQ> faqList;
@@ -111,7 +113,7 @@ public class OneDayClass extends BaseEntity {
     @OneToMany(mappedBy = "oneDayClass", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<ClassTag> tagList;
 
-     public void addReview(Review review) {
+    public void addReview(Review review) {
         this.reviewList.add(review);
         this.totalStarRate += review.getRating();
         this.totalReviews++;
@@ -123,7 +125,7 @@ public class OneDayClass extends BaseEntity {
         this.totalReviews--;
     }
 
-    public void updateTotalStarRate(Double diff) {
+    public void addStartRateDiff(Double diff) {
         this.totalStarRate += diff;
     }
 
@@ -133,7 +135,7 @@ public class OneDayClass extends BaseEntity {
         this.totalAge += userAge;
         this.averageAge = Math.round(totalAge / studentCount * 100.0) / 100.0;
 
-        if(userGender == Gender.MALE) {
+        if (userGender == Gender.MALE) {
             this.maleCount = this.maleCount != null ? this.maleCount + 1 : 1;
         } else {
             this.femaleCount = this.femaleCount != null ? this.femaleCount + 1 : 1;

--- a/src/main/java/com/linked/classbridge/domain/ReviewImage.java
+++ b/src/main/java/com/linked/classbridge/domain/ReviewImage.java
@@ -12,9 +12,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/linked/classbridge/dto/review/GetReviewImageDto.java
+++ b/src/main/java/com/linked/classbridge/dto/review/GetReviewImageDto.java
@@ -1,0 +1,28 @@
+package com.linked.classbridge.dto.review;
+
+import com.linked.classbridge.domain.ReviewImage;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NotNull
+@AllArgsConstructor
+public class GetReviewImageDto {
+
+    private Long imageId;
+    private Integer sequence;
+    private String url;
+
+    public static List<GetReviewImageDto> fromEntityListToDtoList(List<ReviewImage> reviewImageList) {
+        return reviewImageList.stream()
+                .map(reviewImage -> new GetReviewImageDto(
+                        reviewImage.getReviewImageId(),
+                        reviewImage.getSequence(),
+                        reviewImage.getUrl()
+                )).toList();
+    }
+}

--- a/src/main/java/com/linked/classbridge/dto/review/GetReviewResponse.java
+++ b/src/main/java/com/linked/classbridge/dto/review/GetReviewResponse.java
@@ -1,7 +1,6 @@
 package com.linked.classbridge.dto.review;
 
 import com.linked.classbridge.domain.Review;
-import com.linked.classbridge.domain.ReviewImage;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,7 +16,7 @@ public record GetReviewResponse(
         String contents,
         LocalDate lessonDate,
         LocalDateTime createdAt,
-        List<String> reviewImageUrlList
+        List<GetReviewImageDto> reviewImageList
 ) {
     public static GetReviewResponse fromEntity(Review review) {
 
@@ -32,9 +31,7 @@ public record GetReviewResponse(
                 review.getContents(),
                 review.getLesson().getLessonDate(),
                 review.getCreatedAt(),
-                review.getReviewImageList().stream()
-                        .map(ReviewImage::getUrl)
-                        .toList()
+                GetReviewImageDto.fromEntityListToDtoList(review.getReviewImageList())
         );
 
     }

--- a/src/main/java/com/linked/classbridge/dto/review/RegisterReviewDto.java
+++ b/src/main/java/com/linked/classbridge/dto/review/RegisterReviewDto.java
@@ -10,7 +10,6 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import org.springframework.web.multipart.MultipartFile;
 
 public class RegisterReviewDto {
 
@@ -32,10 +31,8 @@ public class RegisterReviewDto {
             @Min(value = 0, message = "평점은 0 이상 5 이하로 입력해 주세요.")
             @Max(value = 5, message = "평점은 0 이상 5 이하로 입력해 주세요.")
             @NotNull(message = "평점을 입력해 주세요.")
-            Double rating,
-            MultipartFile image1,
-            MultipartFile image2,
-            MultipartFile image3
+            Double rating
+
     ) {
 
         public static Review toEntity(

--- a/src/main/java/com/linked/classbridge/dto/review/UpdateReviewDto.java
+++ b/src/main/java/com/linked/classbridge/dto/review/UpdateReviewDto.java
@@ -10,7 +10,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import org.springframework.web.multipart.MultipartFile;
+import java.util.List;
 
 public class UpdateReviewDto {
 
@@ -25,9 +25,8 @@ public class UpdateReviewDto {
             @Max(value = 5, message = "평점은 0 이상 5 이하로 입력해 주세요.")
             @NotNull(message = "평점을 입력해 주세요.")
             Double rating,
-            MultipartFile image1,
-            MultipartFile image2,
-            MultipartFile image3
+
+            List<UpdateReviewImageDto> updateReviewImageRequest
     ) {
 
         public static Review toEntity(

--- a/src/main/java/com/linked/classbridge/dto/review/UpdateReviewImageDto.java
+++ b/src/main/java/com/linked/classbridge/dto/review/UpdateReviewImageDto.java
@@ -1,0 +1,20 @@
+package com.linked.classbridge.dto.review;
+
+import com.linked.classbridge.type.ImageUpdateAction;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NotNull
+@AllArgsConstructor
+public class UpdateReviewImageDto {
+
+    private Long imageId;
+
+    private Integer sequence;
+
+    private ImageUpdateAction action;
+}

--- a/src/main/java/com/linked/classbridge/service/ReviewService.java
+++ b/src/main/java/com/linked/classbridge/service/ReviewService.java
@@ -2,6 +2,7 @@ package com.linked.classbridge.service;
 
 import static com.linked.classbridge.type.ErrorCode.CLASS_NOT_FOUND;
 import static com.linked.classbridge.type.ErrorCode.USER_NOT_FOUND;
+import static com.linked.classbridge.type.ImageUpdateAction.ADD;
 
 import com.linked.classbridge.domain.Lesson;
 import com.linked.classbridge.domain.OneDayClass;
@@ -14,6 +15,7 @@ import com.linked.classbridge.dto.review.GetReviewResponse;
 import com.linked.classbridge.dto.review.RegisterReviewDto;
 import com.linked.classbridge.dto.review.RegisterReviewDto.Request;
 import com.linked.classbridge.dto.review.UpdateReviewDto;
+import com.linked.classbridge.dto.review.UpdateReviewImageDto;
 import com.linked.classbridge.exception.RestApiException;
 import com.linked.classbridge.repository.OneDayClassDocumentRepository;
 import com.linked.classbridge.repository.ReviewImageRepository;
@@ -21,6 +23,7 @@ import com.linked.classbridge.repository.ReviewRepository;
 import com.linked.classbridge.repository.UserRepository;
 import com.linked.classbridge.type.ErrorCode;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.data.domain.Page;
@@ -34,17 +37,12 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ReviewService {
-
     private final ReviewRepository reviewRepository;
-
     private final ReviewImageRepository reviewImageRepository;
-
     private final LessonService lessonService;
-
     private final S3Service s3Service;
     private final OneDayClassService classService;
     private final UserRepository userRepository;
-
     private final ElasticsearchOperations operations;
     private final OneDayClassDocumentRepository oneDayClassDocumentRepository;
 
@@ -55,7 +53,8 @@ public class ReviewService {
      * @return 리뷰 등록 응답
      */
     @Transactional
-    public RegisterReviewDto.Response registerReview(User user, RegisterReviewDto.Request request) {
+    public RegisterReviewDto.Response registerReview(User user, RegisterReviewDto.Request request,
+                                                     MultipartFile[] reviewImages) {
         validateRegisterReview(request);
 
         Lesson lesson = lessonService.findLessonById(request.lessonId());
@@ -70,8 +69,9 @@ public class ReviewService {
         Review savedReview =
                 reviewRepository.save(Request.toEntity(user, lesson, oneDayClass, request));
 
-        uploadAndSaveReviewImage(savedReview, request.image1(), request.image2(), request.image3());
-        oneDayClass.addReview(savedReview); // 평점 등록
+        uploadAndSaveReviewImage(savedReview, reviewImages);
+
+        oneDayClass.addReview(savedReview);
 
         updateOneDayClassDocumentStarRate(oneDayClass);
 
@@ -87,8 +87,7 @@ public class ReviewService {
      * @return 수정된 리뷰 응답
      */
     @Transactional
-    public UpdateReviewDto.Response updateReview(User user, UpdateReviewDto.Request request,
-                                                 Long reviewId) {
+    public UpdateReviewDto.Response updateReview(User user, UpdateReviewDto.Request request, Long reviewId) {
         validateUpdateReview(request);
 
         Review review = findReviewById(reviewId);
@@ -96,14 +95,12 @@ public class ReviewService {
 
         validateReviewOwner(user, review);
 
-        updateReviewImage(review, request.image1(), request.image2(), request.image3());
-
         Double prevRating = review.getRating();
         Double diffRating = request.rating() - prevRating; // 평점 차이 계산
 
         review.update(request.contents(), request.rating());
 
-        oneDayClass.updateTotalStarRate(diffRating); // 평점 업데이트
+        oneDayClass.addStartRateDiff(diffRating); // 평점 업데이트
 
         updateOneDayClassDocumentStarRate(oneDayClass);
 
@@ -123,6 +120,8 @@ public class ReviewService {
         reviewImages.forEach(reviewImage -> s3Service.delete(reviewImage.getUrl()));
 
         review.getOneDayClass().removeReview(review);
+
+        updateOneDayClassDocumentStarRate(review.getOneDayClass());
 
         reviewRepository.delete(review);
 
@@ -152,19 +151,16 @@ public class ReviewService {
         }
     }
 
-    private void uploadAndSaveReviewImage(Review savedReview, MultipartFile... images) {
+    private void uploadAndSaveReviewImage(Review savedReview, MultipartFile[] images) {
         // 리뷰 이미지 등록
         int sequence = 1;
         for (MultipartFile image : images) {
-            if (image != null && !image.isEmpty()) {
-                String url = s3Service.uploadReviewImage(image);
-                reviewImageRepository.save(ReviewImage.builder()
-                        .review(savedReview)
-                        .url(url)
-                        .sequence(sequence++)
-                        .build());
-
-            }
+            String url = s3Service.uploadReviewImage(image);
+            reviewImageRepository.save(ReviewImage.builder()
+                    .review(savedReview)
+                    .url(url)
+                    .sequence(sequence++)
+                    .build());
         }
     }
 
@@ -186,28 +182,50 @@ public class ReviewService {
     }
 
 
-    private void updateReviewImage(Review review, MultipartFile... images) {
-        List<ReviewImage> reviewImages =
-                reviewImageRepository.findByReviewOrderBySequenceAsc(review);
-        int sequence = 1;
-        for (MultipartFile image : images) {
-            if (image != null && !image.isEmpty()) {
-                if (sequence > reviewImages.size()) {
-                    String url = s3Service.uploadReviewImage(image);
-                    reviewImageRepository.save(ReviewImage.builder()
+    @Transactional
+    public void updateReviewImages(User user, Long reviewId,
+                                   List<UpdateReviewImageDto> updateReviewImageDtoList,
+                                   MultipartFile[] reviewImages) {
+        Review review = findReviewById(reviewId);
+
+        validateReviewOwner(user, review);
+
+        List<ReviewImage> reviewImagesList = reviewImageRepository.findByReviewOrderBySequenceAsc(review);
+
+        for (UpdateReviewImageDto updateReviewImageDto : updateReviewImageDtoList) {
+            ReviewImage reviewImage = updateReviewImageDto.getAction() == ADD ?
+                    null :
+                    reviewImagesList.stream()
+                            .filter(image ->
+                                    Objects.equals(image.getReviewImageId(), updateReviewImageDto.getImageId()))
+                            .findFirst()
+                            .orElseThrow(() -> new RestApiException(ErrorCode.REVIEW_IMAGE_NOT_FOUND));
+
+            switch (updateReviewImageDto.getAction()) {
+                case KEEP -> {
+                    reviewImage.setSequence(updateReviewImageDto.getSequence());
+                }
+                case ADD -> {
+                    String url = s3Service.uploadReviewImage(reviewImages[updateReviewImageDto.getSequence() - 1]);
+                    reviewImage = ReviewImage.builder()
                             .review(review)
                             .url(url)
-                            .sequence(sequence)
-                            .build());
-                } else {
-                    ReviewImage reviewImage = reviewImages.get(sequence - 1);
-                    String prevImageUrl = reviewImage.getUrl();
-                    s3Service.delete(prevImageUrl);
-                    String url = s3Service.uploadReviewImage(image);
-                    reviewImage.updateUrl(url);
+                            .sequence(updateReviewImageDto.getSequence())
+                            .build();
+                    reviewImageRepository.save(reviewImage);
                 }
+                case DELETE -> {
+                    s3Service.delete(reviewImage.getUrl());
+                    reviewImageRepository.delete(reviewImage);
+                }
+                case REPLACE -> {
+                    s3Service.delete(reviewImage.getUrl());
+                    String newUrl = s3Service.uploadReviewImage(reviewImages[updateReviewImageDto.getSequence() - 1]);
+                    reviewImage.updateUrl(newUrl);
+                    reviewImage.setSequence(updateReviewImageDto.getSequence());
+                }
+                default -> throw new RestApiException(ErrorCode.INVALID_REVIEW_IMAGE_ACTION);
             }
-            sequence++;
         }
     }
 
@@ -265,8 +283,10 @@ public class ReviewService {
     }
 
     private void updateOneDayClassDocumentStarRate(OneDayClass oneDayClass) {
-        OneDayClassDocument oneDayClassDocument = oneDayClassDocumentRepository.findById(oneDayClass.getClassId()).orElseThrow(() -> new RestApiException(CLASS_NOT_FOUND));
-        oneDayClassDocument.setStarRate(oneDayClass.getTotalStarRate() / (oneDayClass.getTotalReviews() == 0 ? 1 : oneDayClass.getTotalReviews()));
+        OneDayClassDocument oneDayClassDocument = oneDayClassDocumentRepository.findById(oneDayClass.getClassId())
+                .orElseThrow(() -> new RestApiException(CLASS_NOT_FOUND));
+        oneDayClassDocument.setStarRate(oneDayClass.getTotalStarRate() / (oneDayClass.getTotalReviews() == 0 ? 1
+                : oneDayClass.getTotalReviews()));
         operations.save(oneDayClassDocument);
     }
 }

--- a/src/main/java/com/linked/classbridge/service/S3Service.java
+++ b/src/main/java/com/linked/classbridge/service/S3Service.java
@@ -12,13 +12,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
-@Transactional(readOnly = true)
 public class S3Service {
 
     private final AmazonS3Client s3Client;
@@ -35,31 +33,21 @@ public class S3Service {
 
     private static final String ONE_DAY_CLASS_FOLDER = "oneDayClass/";
 
-    @Transactional
     public String uploadReviewImage(MultipartFile image) {
 
         return uploadImage(image, REVIEW_FOLDER);
     }
 
-    @Transactional
     public String uploadOneDayClassImage(MultipartFile image) {
         return uploadImage(image, ONE_DAY_CLASS_FOLDER);
     }
 
-    @Transactional
     public String uploadUserProfileImage(MultipartFile image) {
 
         return uploadImage(image, USER_PROFILE_FOLDER);
     }
 
-    /**
-     * S3에 파일 업로드
-     *
-     * @param file   파일
-     * @param folder 폴더
-     * @return 업로드된 파일 URL
-     */
-    @Transactional
+
     public String uploadImage(MultipartFile file, String folder) {
         String fileName = folder + UUID.randomUUID() + file.getOriginalFilename();
 
@@ -86,7 +74,7 @@ public class S3Service {
      *
      * @param url 이미지 URL
      */
-    @Transactional
+
     public void delete(String url) {
         try {
             s3Client.deleteObject(bucket, getFileNameFromURL(url));

--- a/src/main/java/com/linked/classbridge/type/ErrorCode.java
+++ b/src/main/java/com/linked/classbridge/type/ErrorCode.java
@@ -33,8 +33,11 @@ public enum ErrorCode {
     INVALID_REVIEW_RATING(HttpStatus.BAD_REQUEST, "리뷰 평점은 1점부터 5점까지 가능합니다."),
     INVALID_REVIEW_CONTENTS(HttpStatus.BAD_REQUEST, "리뷰 내용은 10자 이상 200자 이하로 작성해주세요."),
     INVALID_IMAGE_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "유효한 이미지 파일이 아닙니다."),
+    REVIEW_IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "리뷰 이미지를 찾을 수 없습니다."),
+    INVALID_REVIEW_IMAGE_ACTION(HttpStatus.BAD_REQUEST, "유효하지 않은 이미지 업로드 액션입니다."),
     FAILED_TO_UPLOAD_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다."),
     FAILED_TO_DELETE_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 삭제에 실패했습니다."),
+
 
     LESSON_NOT_FOUND(HttpStatus.BAD_REQUEST, "클래스를 찾을 수 없습니다."),
     REVIEW_NOT_FOUND(HttpStatus.BAD_REQUEST, "리뷰를 찾을 수 없습니다."),
@@ -78,8 +81,8 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
     INVALID_PAYMENT_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 정보입니다."),
     NULL_RESPONSE_FROM_PAYMENT_GATEWAY(HttpStatus.BAD_REQUEST, "결제 게이트웨이 응답이 없습니다."),
-    MISSING_PAY_RESPONSE_IN_SESSION(HttpStatus.BAD_REQUEST,"세션에 결제 정보가 없습니다."),
-    INVALID_REFUND_QUANTITY(HttpStatus.BAD_REQUEST,"환불 가능 수량을 확인해주세요."),
+    MISSING_PAY_RESPONSE_IN_SESSION(HttpStatus.BAD_REQUEST, "세션에 결제 정보가 없습니다."),
+    INVALID_REFUND_QUANTITY(HttpStatus.BAD_REQUEST, "환불 가능 수량을 확인해주세요."),
     INVALID_RESERVATION_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 예약입니다."),
     NO_REFUND_AVAILABLE(HttpStatus.BAD_REQUEST, "환불 가능 금액이 아닙니다."),
     REFUND_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 환불입니다."),
@@ -96,8 +99,8 @@ public enum ErrorCode {
     USER_NOT_IN_CHAT_ROOM(HttpStatus.BAD_REQUEST, "채팅방에 참여하지 않은 사용자입니다."),
 
     NOT_TODAY_LESSON(HttpStatus.BAD_REQUEST, "레슨 당일에만 출석체크가 가능합니다."),
-    NOT_YET_ATTENDANCE(HttpStatus.BAD_REQUEST, "레슨 시작 30분 전부터 출석체크가 가능합니다."),
-    ;
+    NOT_YET_ATTENDANCE(HttpStatus.BAD_REQUEST, "레슨 시작 30분 전부터 출석체크가 가능합니다.");
+
     private final HttpStatus httpStatus;
     private final String description;
 }

--- a/src/main/java/com/linked/classbridge/type/ImageUpdateAction.java
+++ b/src/main/java/com/linked/classbridge/type/ImageUpdateAction.java
@@ -1,0 +1,6 @@
+package com.linked.classbridge.type;
+
+public enum ImageUpdateAction {
+    KEEP, ADD, DELETE, REPLACE
+
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -94,3 +94,5 @@ openapi:
 kakaomap:
   admin-key: ${KAKAO_MAP_ADMIN_KEY}
   map-url: https://dapi.kakao.com/v2/local/search/address.json
+
+baseUrl: http://localhost:8080

--- a/src/test/java/com/linked/classbridge/ClassBridgeApplicationTests.java
+++ b/src/test/java/com/linked/classbridge/ClassBridgeApplicationTests.java
@@ -2,12 +2,14 @@ package com.linked.classbridge;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 
-@SpringBootTest
+@SpringBootTest(classes = ClassBridgeApplication.class)
+@TestPropertySource(locations = "classpath:application-test.yml")
 class ClassBridgeApplicationTests {
 
-  @Test
-  void contextLoads() {
-  }
+    @Test
+    void contextLoads() {
+    }
 
 }

--- a/src/test/java/com/linked/classbridge/controller/OneDayClassControllerTest.java
+++ b/src/test/java/com/linked/classbridge/controller/OneDayClassControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.linked.classbridge.dto.review.GetReviewImageDto;
 import com.linked.classbridge.dto.review.GetReviewResponse;
 import com.linked.classbridge.exception.RestApiException;
 import com.linked.classbridge.service.OneDayClassService;
@@ -62,14 +63,14 @@ class OneDayClassControllerTest {
                 "userNickname1", 4.5, "content1",
                 LocalDate.of(2024, 6, 1),
                 LocalDateTime.of(2024, 6, 3, 15, 0),
-                List.of("url1", "url2", "url3")
+                List.of(new GetReviewImageDto(1L, 1, "url1"))
         );
         reviewResponse2 = new GetReviewResponse(
                 2L, 1L, "className", 2L, 2L,
                 "userNickname2", 2.3, "content2",
                 LocalDate.of(2024, 6, 1),
                 LocalDateTime.of(2024, 6, 2, 17, 0),
-                List.of("url4", "url5", "url6")
+                List.of(new GetReviewImageDto(2L, 2, "url2"))
         );
     }
 

--- a/src/test/java/com/linked/classbridge/controller/TutorControllerTest.java
+++ b/src/test/java/com/linked/classbridge/controller/TutorControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linked.classbridge.domain.User;
+import com.linked.classbridge.dto.review.GetReviewImageDto;
 import com.linked.classbridge.dto.review.GetReviewResponse;
 import com.linked.classbridge.dto.tutor.TutorInfoDto;
 import com.linked.classbridge.exception.RestApiException;
@@ -84,22 +85,22 @@ class TutorControllerTest {
         reviewResponse1 = new GetReviewResponse(
                 1L, 1L, "className", 1L, 1L,
                 "userNickname", 4.5, "review1 content",
-                LocalDate.now(), LocalDateTime.now(), List.of("url1", "url2", "url3")
+                LocalDate.now(), LocalDateTime.now(), List.of(new GetReviewImageDto(1L, 1, "url1"))
         );
         reviewResponse2 = new GetReviewResponse(
                 1L, 1L, "className", 2L, 1L,
                 "userNickname", 4.5, "review1 content",
-                LocalDate.now(), LocalDateTime.now(), List.of("url1", "url2", "url3")
+                LocalDate.now(), LocalDateTime.now(), List.of(new GetReviewImageDto(2L, 1, "url2"))
         );
         reviewResponse3 = new GetReviewResponse(
                 1L, 2L, "className", 3L, 2L,
                 "userNickname", 4.5, "review1 content",
-                LocalDate.now(), LocalDateTime.now(), List.of("url1", "url2", "url3")
+                LocalDate.now(), LocalDateTime.now(), List.of(new GetReviewImageDto(3L, 1, "url3"))
         );
         reviewResponse4 = new GetReviewResponse(
                 1L, 2L, "className", 4L, 2L,
                 "userNickname", 4.5, "review1 content",
-                LocalDate.now(), LocalDateTime.now(), List.of("url1", "url2", "url3")
+                LocalDate.now(), LocalDateTime.now(), List.of(new GetReviewImageDto(4L, 1, "url4"))
         );
     }
 

--- a/src/test/java/com/linked/classbridge/controller/UserControllerTest.java
+++ b/src/test/java/com/linked/classbridge/controller/UserControllerTest.java
@@ -17,6 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linked.classbridge.domain.User;
+import com.linked.classbridge.dto.review.GetReviewImageDto;
 import com.linked.classbridge.dto.review.GetReviewResponse;
 import com.linked.classbridge.dto.user.AdditionalInfoDto;
 import com.linked.classbridge.dto.user.AuthDto;
@@ -119,28 +120,28 @@ class UserControllerTest {
                 "userNickname", 4.5, "review1 content",
                 LocalDate.of(2024, 6, 1),
                 LocalDateTime.of(2024, 6, 3, 15, 0),
-                List.of("url1", "url2", "url3")
+                List.of(new GetReviewImageDto(1L, 1, "url1"))
         );
         reviewResponse2 = new GetReviewResponse(
                 2L, 1L, "className", 2L, 1L,
                 "userNickname", 2.3, "review2 content",
                 LocalDate.of(2024, 6, 1),
                 LocalDateTime.of(2024, 6, 2, 17, 0),
-                List.of("url4", "url5", "url6")
+                List.of(new GetReviewImageDto(1L, 1, "url1"))
         );
         reviewResponse3 = new GetReviewResponse(
                 3L, 2L, "className", 3L, 1L,
                 "userNickname", 3.7, "review3 content",
                 LocalDate.of(2024, 6, 1),
                 LocalDateTime.of(2024, 6, 1, 20, 0),
-                List.of("url7", "url8", "url9")
+                List.of(new GetReviewImageDto(1L, 1, "url1"))
         );
         reviewResponse4 = new GetReviewResponse(
                 4L, 2L, "className", 4L, 1L,
                 "userNickname", 5.0, "review4 content",
                 LocalDate.of(2024, 6, 1),
                 LocalDateTime.of(2024, 6, 1, 23, 0),
-                List.of("url10", "url11", "url12")
+                List.of(new GetReviewImageDto(1L, 1, "url1"))
         );
     }
 

--- a/src/test/java/com/linked/classbridge/service/ReviewServiceTest.java
+++ b/src/test/java/com/linked/classbridge/service/ReviewServiceTest.java
@@ -4,10 +4,15 @@ import static com.linked.classbridge.type.ErrorCode.CLASS_NOT_FOUND;
 import static com.linked.classbridge.type.ErrorCode.INVALID_ONE_DAY_CLASS_ID;
 import static com.linked.classbridge.type.ErrorCode.INVALID_REVIEW_CONTENTS;
 import static com.linked.classbridge.type.ErrorCode.INVALID_REVIEW_RATING;
+import static com.linked.classbridge.type.ImageUpdateAction.ADD;
+import static com.linked.classbridge.type.ImageUpdateAction.DELETE;
+import static com.linked.classbridge.type.ImageUpdateAction.KEEP;
+import static com.linked.classbridge.type.ImageUpdateAction.REPLACE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -24,6 +29,7 @@ import com.linked.classbridge.dto.review.GetReviewResponse;
 import com.linked.classbridge.dto.review.RegisterReviewDto;
 import com.linked.classbridge.dto.review.RegisterReviewDto.Request;
 import com.linked.classbridge.dto.review.UpdateReviewDto;
+import com.linked.classbridge.dto.review.UpdateReviewImageDto;
 import com.linked.classbridge.exception.RestApiException;
 import com.linked.classbridge.repository.OneDayClassDocumentRepository;
 import com.linked.classbridge.repository.ReviewImageRepository;
@@ -52,33 +58,24 @@ import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
 class ReviewServiceTest {
-
     @Mock
     private OneDayClassService oneDayClassService;
     @Mock
     private ReviewRepository reviewRepository;
-
     @Mock
     private ReviewImageRepository reviewImageRepository;
-
     @Mock
     private UserRepository userRepository;
-
     @Mock
     private LessonService lessonService;
-
     @Mock
     private S3Service s3Service;
-
     @InjectMocks
     private ReviewService reviewService;
-
     @Mock
     private OneDayClassDocumentRepository oneDayClassDocumentRepository;
-
     @Mock
     private ElasticsearchOperations operations;
-
     private User mockUser1;
     private User mockUser2;
     private User tutor;
@@ -86,12 +83,10 @@ class ReviewServiceTest {
     private Lesson mockLesson2;
     private OneDayClass mockOneDayClass1;
     private OneDayClass mockOneDayClass2;
-
     private Review mockReview1;
     private Review mockReview2;
     private Review mockReview3;
     private Review mockReview4;
-
     private ReviewImage mockReviewImage1;
     private ReviewImage mockReviewImage2;
     private ReviewImage mockReviewImage3;
@@ -243,20 +238,15 @@ class ReviewServiceTest {
     }
 
     private RegisterReviewDto.Request createRegisterReviewDtoRequest() {
-        MultipartFile image1 = mock(MultipartFile.class);
-        MultipartFile image2 = mock(MultipartFile.class);
-        MultipartFile image3 = mock(MultipartFile.class);
         return new RegisterReviewDto.Request(
                 mockLesson1.getLessonId(), mockOneDayClass1.getClassId(),
-                mockReview1.getContents(), mockReview1.getRating(), image1, image2, image3);
+                mockReview1.getContents(), mockReview1.getRating());
     }
 
     private UpdateReviewDto.Request createUpdateReviewDtoRequest() {
-        MultipartFile image1 = mock(MultipartFile.class);
-        MultipartFile image2 = mock(MultipartFile.class);
-        MultipartFile image3 = mock(MultipartFile.class);
+        UpdateReviewImageDto updateReviewImageDto1 = new UpdateReviewImageDto(1L, 1, ADD);
         return new UpdateReviewDto.Request(
-                "This is a update contents.", 3.0, image1, image2, image3);
+                "This is a update contents.", 3.0, List.of(updateReviewImageDto1));
     }
 
     @Test
@@ -280,10 +270,8 @@ class ReviewServiceTest {
         assertEquals(response.contents(), mockReview1.getContents());
         assertEquals(response.lessonDate(), mockReview1.getLesson().getLessonDate());
         assertEquals(response.createdAt(), mockReview1.getCreatedAt());
-        assertThat(response.reviewImageUrlList()).containsExactly(
-                mockReview1.getReviewImageList().get(0).getUrl(),
-                mockReview1.getReviewImageList().get(1).getUrl(),
-                mockReview1.getReviewImageList().get(2).getUrl());
+        assertEquals(response.reviewImageList().size(), mockReview1.getReviewImageList().size());
+
     }
 
     @Test
@@ -304,11 +292,12 @@ class ReviewServiceTest {
     @DisplayName("리뷰 등록 성공")
     void createReview_success() {
         // given
-        String url1 = mockReviewImage1.getUrl();
-        String url2 = mockReviewImage2.getUrl();
-        String url3 = mockReviewImage3.getUrl();
-
         RegisterReviewDto.Request request = createRegisterReviewDtoRequest();
+
+        MultipartFile image1 = mock(MultipartFile.class);
+        String url1 = mockReviewImage1.getUrl();
+
+        MultipartFile[] images = new MultipartFile[]{image1};
 
         Review reviewToSave = RegisterReviewDto.Request.toEntity(mockUser1, mockLesson1,
                 mockOneDayClass1, request);
@@ -319,31 +308,27 @@ class ReviewServiceTest {
         given(reviewRepository.findByLessonAndUser(mockLesson1, mockUser1))
                 .willReturn(Optional.empty());
         given(lessonService.findLessonById(1L)).willReturn(mockLesson1);
-        given(s3Service.uploadReviewImage(request.image1())).willReturn(url1);
-        given(s3Service.uploadReviewImage(request.image2())).willReturn(url2);
-        given(s3Service.uploadReviewImage(request.image3())).willReturn(url3);
+        given(s3Service.uploadReviewImage(image1)).willReturn(url1);
         given(reviewRepository.save(reviewToSave)).willReturn(savedReview);
 
         given(oneDayClassDocumentRepository.findById(mockOneDayClass1.getClassId())).willReturn(
                 Optional.of(oneDayClassDocument));
 
         // when
-        RegisterReviewDto.Response response = reviewService.registerReview(mockUser1, request);
+        RegisterReviewDto.Response response = reviewService.registerReview(mockUser1, request, images);
 
         // then
         assertNotNull(response);
         assertEquals(response.reviewId(), savedReview.getReviewId());
 
         verify(reviewRepository, times(1)).save(reviewToSave);
-        verify(s3Service, times(1)).uploadReviewImage(request.image1());
-        verify(s3Service, times(1)).uploadReviewImage(request.image2());
-        verify(s3Service, times(1)).uploadReviewImage(request.image3());
+        verify(s3Service, times(1)).uploadReviewImage(image1);
 
         ArgumentCaptor<ReviewImage> reviewImageCaptor = ArgumentCaptor.forClass(ReviewImage.class);
-        verify(reviewImageRepository, times(3)).save(reviewImageCaptor.capture());
+        verify(reviewImageRepository, times(1)).save(reviewImageCaptor.capture());
 
         List<ReviewImage> capturedReviewImages = reviewImageCaptor.getAllValues();
-        assertThat(capturedReviewImages).extracting("url").containsExactly(url1, url2, url3);
+        assertThat(capturedReviewImages).extracting("url").containsExactly(url1);
     }
 
     @Test
@@ -352,13 +337,15 @@ class ReviewServiceTest {
         // given
         RegisterReviewDto.Request request = createRegisterReviewDtoRequest();
 
+        MultipartFile[] images = new MultipartFile[]{mock(MultipartFile.class)};
+
         given(lessonService.findLessonById(request.lessonId())).willReturn(mockLesson1);
         given(reviewRepository.findByLessonAndUser(mockLesson1, mockUser1))
                 .willReturn(Optional.of(Review.builder().reviewId(1L).build()));
 
         // when
         RestApiException exception = assertThrows(RestApiException.class,
-                () -> reviewService.registerReview(mockUser1, request));
+                () -> reviewService.registerReview(mockUser1, request, images));
 
         // then
         assertEquals(ErrorCode.REVIEW_ALREADY_EXISTS, exception.getErrorCode());
@@ -368,37 +355,24 @@ class ReviewServiceTest {
     @DisplayName("리뷰 등록 실패 - 평점 범위 초과")
     void createReview_fail_invalidRating() {
         // given
-        RegisterReviewDto.Request request = new Request(1L, 1L, "valid contents", 5.1,
-                mock(MultipartFile.class), mock(MultipartFile.class), mock(MultipartFile.class));
+        MultipartFile[] images = new MultipartFile[]{mock(MultipartFile.class)};
+        RegisterReviewDto.Request request = new Request(1L, 1L, "valid contents", 5.1);
 
         // when
         RestApiException exception = assertThrows(RestApiException.class,
-                () -> reviewService.registerReview(mockUser1, request));
+                () -> reviewService.registerReview(mockUser1, request, images));
 
         // then
         assertEquals(INVALID_REVIEW_RATING, exception.getErrorCode());
     }
 
-    @Test
-    @DisplayName("리뷰 등록 실패 - 리뷰 내용 길이 부족")
-    void createReview_fail_invalidReviewContents() {
-        // given
-        RegisterReviewDto.Request request = new Request(1L, 1L, "short", 4.5,
-                mock(MultipartFile.class), mock(MultipartFile.class), mock(MultipartFile.class));
-
-        // when
-        RestApiException exception = assertThrows(RestApiException.class,
-                () -> reviewService.registerReview(mockUser1, request));
-
-        // then
-        assertEquals(INVALID_REVIEW_CONTENTS, exception.getErrorCode());
-    }
 
     @Test
     @DisplayName("리뷰 등록 실패 - 클래스 정보 일치 하지 않음")
     void createReview_fail_notMatchClass() {
         // given
         RegisterReviewDto.Request request = createRegisterReviewDtoRequest();
+        MultipartFile[] images = new MultipartFile[]{mock(MultipartFile.class)};
 
         mockOneDayClass1 = OneDayClass.builder()
                 .classId(2L)
@@ -413,7 +387,7 @@ class ReviewServiceTest {
 
         // when
         RestApiException exception = assertThrows(RestApiException.class,
-                () -> reviewService.registerReview(mockUser1, request));
+                () -> reviewService.registerReview(mockUser1, request, images));
 
         // then
         assertEquals(INVALID_ONE_DAY_CLASS_ID, exception.getErrorCode());
@@ -444,9 +418,6 @@ class ReviewServiceTest {
         assertEquals(response.rating(), request.rating());
 
         verify(reviewRepository, times(1)).findById(reviewId);
-        verify(s3Service, times(1)).uploadReviewImage(request.image1());
-        verify(s3Service, times(1)).uploadReviewImage(request.image2());
-        verify(s3Service, times(1)).uploadReviewImage(request.image3());
     }
 
     @Test
@@ -491,8 +462,7 @@ class ReviewServiceTest {
         // given
         Long reviewId = 1L;
         UpdateReviewDto.Request request = new UpdateReviewDto.Request(
-                "This is a update contents.", 5.1,
-                mock(MultipartFile.class), mock(MultipartFile.class), mock(MultipartFile.class));
+                "This is a update contents.", 5.1, List.of());
 
         // when
         RestApiException exception = assertThrows(RestApiException.class,
@@ -508,8 +478,7 @@ class ReviewServiceTest {
         // given
         Long reviewId = 1L;
         UpdateReviewDto.Request request = new UpdateReviewDto.Request(
-                "short", 3.0,
-                mock(MultipartFile.class), mock(MultipartFile.class), mock(MultipartFile.class));
+                "short", 3.0, List.of());
 
         // when
         RestApiException exception = assertThrows(RestApiException.class,
@@ -526,11 +495,13 @@ class ReviewServiceTest {
         Long reviewId = 1L;
 
         Review savedReview = mockReview1;
+        OneDayClassDocument oneDayClassDocument = OneDayClassDocument.builder().classId(1L).build();
 
         given(reviewRepository.findById(reviewId)).willReturn(Optional.of(savedReview));
         given(reviewImageRepository.findByReviewOrderBySequenceAsc(savedReview))
                 .willReturn(savedReview.getReviewImageList());
-
+        given(oneDayClassDocumentRepository.findById(mockOneDayClass1.getClassId())).willReturn(
+                Optional.of(oneDayClassDocument));
         // when
         DeleteReviewResponse response = reviewService.deleteReview(mockUser1, reviewId);
 
@@ -672,5 +643,168 @@ class ReviewServiceTest {
         assertThat(responses).extracting("lessonDate").containsExactly(
                 mockLesson1.getLessonDate(), mockLesson1.getLessonDate(),
                 mockLesson2.getLessonDate(), mockLesson2.getLessonDate());
+    }
+
+    @Test
+    @DisplayName("리뷰 이미지 업데이트 - KEEP")
+    void testUpdateReviewImages_KEEP() {
+        // given
+        Long reviewId = 1L;
+        List<UpdateReviewImageDto> updateReviewImageDtoList = List.of(
+                new UpdateReviewImageDto(1L, 1, KEEP),
+                new UpdateReviewImageDto(2L, 2, KEEP)
+        );
+
+        List<ReviewImage> reviewImageList = List.of(mockReviewImage1, mockReviewImage2);
+
+        mockReview1 = Review.builder()
+                .reviewId(1L)
+                .user(mockUser1)
+                .lesson(mockLesson1)
+                .oneDayClass(mockOneDayClass1)
+                .contents("review1 contents")
+                .rating(4.5)
+                .createdAt(LocalDateTime.now())
+                .reviewImageList(reviewImageList)
+                .build();
+
+        mockReviewImage1 = ReviewImage.builder()
+                .reviewImageId(1L)
+                .review(mockReview1)
+                .url("url1")
+                .sequence(1)
+                .build();
+
+        mockReviewImage2 = ReviewImage.builder()
+                .reviewImageId(2L)
+                .review(mockReview1)
+                .url("url2")
+                .sequence(2)
+                .build();
+
+        MultipartFile[] images = new MultipartFile[]{mock(MultipartFile.class), mock(MultipartFile.class)};
+
+        given(reviewImageRepository.findByReviewOrderBySequenceAsc(mockReview1)).willReturn(reviewImageList);
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(mockReview1));
+
+        // when
+        reviewService.updateReviewImages(mockUser1, reviewId, updateReviewImageDtoList, images);
+
+        // then
+        verify(s3Service, times(0)).uploadReviewImage(any(MultipartFile.class));
+        verify(s3Service, times(0)).delete(any(String.class));
+    }
+
+    @Test
+    @DisplayName("리뷰 이미지 업데이트 - ADD")
+    void testUpdateReviewImages_ADD() {
+        // given
+        Long reviewId = 1L;
+        List<UpdateReviewImageDto> updateReviewImageDtoList = List.of(
+                new UpdateReviewImageDto(1L, 1, ADD),
+                new UpdateReviewImageDto(2L, 2, ADD)
+        );
+
+        List<ReviewImage> reviewImageList = List.of(mockReviewImage1, mockReviewImage2);
+
+        mockReview1 = Review.builder()
+                .reviewId(1L)
+                .user(mockUser1)
+                .lesson(mockLesson1)
+                .oneDayClass(mockOneDayClass1)
+                .contents("review1 contents")
+                .rating(4.5)
+                .createdAt(LocalDateTime.now())
+                .reviewImageList(reviewImageList)
+                .build();
+
+        MultipartFile[] images = new MultipartFile[]{mock(MultipartFile.class), mock(MultipartFile.class)};
+
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(mockReview1));
+        given(reviewImageRepository.findByReviewOrderBySequenceAsc(mockReview1)).willReturn(reviewImageList);
+        given(s3Service.uploadReviewImage(images[0])).willReturn("url1");
+        given(s3Service.uploadReviewImage(images[1])).willReturn("url2");
+
+        // when
+        reviewService.updateReviewImages(mockUser1, reviewId, updateReviewImageDtoList, images);
+
+        // then
+        verify(s3Service, times(1)).uploadReviewImage(images[0]);
+        verify(s3Service, times(1)).uploadReviewImage(images[1]);
+
+        ArgumentCaptor<ReviewImage> reviewImageCaptor = ArgumentCaptor.forClass(ReviewImage.class);
+        verify(reviewImageRepository, times(2)).save(reviewImageCaptor.capture());
+
+        List<ReviewImage> capturedReviewImages = reviewImageCaptor.getAllValues();
+        assertThat(capturedReviewImages).extracting("url").containsExactly("url1", "url2");
+    }
+
+    @Test
+    @DisplayName("리뷰 이미지 업데이트 - DELETE")
+    void testUpdateReviewImages_DELETE() {
+        //given
+        Long reviewId = 1L;
+        List<UpdateReviewImageDto> updateReviewImageDtoList = List.of(
+                new UpdateReviewImageDto(1L, 1, DELETE)
+
+        );
+        List<ReviewImage> reviewImageList = List.of(mockReviewImage1, mockReviewImage2);
+
+        mockReview1 = Review.builder()
+                .reviewId(1L)
+                .user(mockUser1)
+                .lesson(mockLesson1)
+                .oneDayClass(mockOneDayClass1)
+                .contents("review1 contents")
+                .rating(4.5)
+                .createdAt(LocalDateTime.now())
+                .reviewImageList(reviewImageList)
+                .build();
+
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(mockReview1));
+        given(reviewImageRepository.findByReviewOrderBySequenceAsc(mockReview1)).willReturn(reviewImageList);
+
+        // when
+        reviewService.updateReviewImages(mockUser1, reviewId, updateReviewImageDtoList, null);
+
+        // then
+        verify(s3Service, times(1)).delete("url1");
+        verify(reviewImageRepository, times(1)).delete(any(ReviewImage.class));
+
+    }
+
+    @Test
+    void testUpdateReviewImages_REPLACE() {
+        //given
+        Long reviewId = 1L;
+        MultipartFile[] images = new MultipartFile[]{mock(MultipartFile.class)};
+        List<UpdateReviewImageDto> updateReviewImageDtoList = List.of(
+                new UpdateReviewImageDto(1L, 1, REPLACE)
+
+        );
+        List<ReviewImage> reviewImageList = List.of(mockReviewImage1, mockReviewImage2);
+
+        mockReview1 = Review.builder()
+                .reviewId(1L)
+                .user(mockUser1)
+                .lesson(mockLesson1)
+                .oneDayClass(mockOneDayClass1)
+                .contents("review1 contents")
+                .rating(4.5)
+                .createdAt(LocalDateTime.now())
+                .reviewImageList(reviewImageList)
+                .build();
+
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(mockReview1));
+        given(reviewImageRepository.findByReviewOrderBySequenceAsc(mockReview1)).willReturn(reviewImageList);
+        given(s3Service.uploadReviewImage(images[0])).willReturn("newUrl");
+
+        // when
+        reviewService.updateReviewImages(mockUser1, reviewId, updateReviewImageDtoList, images);
+
+        // then
+        verify(s3Service, times(1)).delete(any(String.class));
+        verify(s3Service, times(1)).uploadReviewImage(images[0]);
+
     }
 }


### PR DESCRIPTION
### 변경사항

- 리뷰 등록 및 수정 요청 방식을 기존 ModelAttribute 방식에서 RequestPart 방식으로 수정했습니다.
- 또한 이미지를 단일 파라미터의 배열로 받도록 변경 했습니다.
![image](https://github.com/ClassBridge/ClassBridge-BE/assets/152583754/0006472c-f20e-4118-9b09-854ba1b7988f)

- 리뷰 수정 시 여러 케이스 (이미지 변경, 일부 이미지 삭제, 이미지 추가)에 맞게 이미지 업데이트 로직을 수정하였습니다.
![image](https://github.com/ClassBridge/ClassBridge-BE/assets/152583754/2feb3735-85aa-469e-9b15-0f3da75c45d9)

리뷰 수정 요청 시 각 이미지 순서에 action을 담아 해당 action에 맞게 이미지의 업데이트가 이루어지게 됩니다.

- 불필요한 transactional 어노테이션 제거 및 메서드명 수정

### 테스트

일부 DTO 구조 및 업데이트 로직의 변경으로 인해 기존 테스트 코드를 일부 수정 및 새로운 케이스에 대한 추가 테스트를 실시하였습니다.

- [x] 테스트 코드
- [x] API 테스트 