### PR TITLE
refactor: 매출 정산 시 클래스 별로 조회 가능하도록 수정

### DIFF
--- a/src/main/java/com/linked/classbridge/controller/TutorPaymentController.java
+++ b/src/main/java/com/linked/classbridge/controller/TutorPaymentController.java
@@ -22,14 +22,14 @@ public class TutorPaymentController {
     private final TutorPaymentService tutorPaymentService;
 
     @GetMapping("/payments")
-    public ResponseEntity<SuccessResponse<List<TutorPaymentResponse>>> getTutorPayments(@RequestParam Long userId,
-                                                                                        @RequestParam(required = false) String yearMonth) {
+    public ResponseEntity<SuccessResponse<List<TutorPaymentResponse>>> getTutorPayments(
+            @RequestParam(required = false) String yearMonth) {
         List<TutorPaymentResponse> tutorPaymentResponseList;
         if (yearMonth != null) {
             YearMonth ym = YearMonth.parse(yearMonth);
-            tutorPaymentResponseList = tutorPaymentService.getTutorPaymentsByUserIdAndPeriod(userId, ym);
+            tutorPaymentResponseList = tutorPaymentService.getTutorPaymentsByUserIdAndPeriod(ym);
         } else {
-            tutorPaymentResponseList = tutorPaymentService.getTutorPaymentsByUserId(userId);
+            tutorPaymentResponseList = tutorPaymentService.getTutorPaymentsByUserId();
         }
         return ResponseEntity.status(HttpStatus.OK).body(
                 SuccessResponse.of(

--- a/src/main/java/com/linked/classbridge/controller/TutorPaymentController.java
+++ b/src/main/java/com/linked/classbridge/controller/TutorPaymentController.java
@@ -4,6 +4,7 @@ import com.linked.classbridge.dto.SuccessResponse;
 import com.linked.classbridge.dto.tutorPayment.TutorPaymentResponse;
 import com.linked.classbridge.service.TutorPaymentService;
 import com.linked.classbridge.type.ResponseMessage;
+import java.time.YearMonth;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,8 +22,15 @@ public class TutorPaymentController {
     private final TutorPaymentService tutorPaymentService;
 
     @GetMapping("/payments")
-    public ResponseEntity<SuccessResponse<List<TutorPaymentResponse>>> getTutorPayments(@RequestParam Long userId) {
-        List<TutorPaymentResponse> tutorPaymentResponseList = tutorPaymentService.getTutorPaymentsByUserId(userId);
+    public ResponseEntity<SuccessResponse<List<TutorPaymentResponse>>> getTutorPayments(@RequestParam Long userId,
+                                                                                        @RequestParam(required = false) String yearMonth) {
+        List<TutorPaymentResponse> tutorPaymentResponseList;
+        if (yearMonth != null) {
+            YearMonth ym = YearMonth.parse(yearMonth);
+            tutorPaymentResponseList = tutorPaymentService.getTutorPaymentsByUserIdAndPeriod(userId, ym);
+        } else {
+            tutorPaymentResponseList = tutorPaymentService.getTutorPaymentsByUserId(userId);
+        }
         return ResponseEntity.status(HttpStatus.OK).body(
                 SuccessResponse.of(
                         ResponseMessage.TUTOR_PAYMENT_GET_SUCCESS,

--- a/src/main/java/com/linked/classbridge/dto/sales/ClassMonthlySales.java
+++ b/src/main/java/com/linked/classbridge/dto/sales/ClassMonthlySales.java
@@ -7,7 +7,9 @@ import lombok.Setter;
 @Getter
 @Setter
 @AllArgsConstructor
-public class MonthlySales {
+public class ClassMonthlySales {
+    private Long classId;
+    private String className;
     private int month;
     private int amount;
 }

--- a/src/main/java/com/linked/classbridge/dto/sales/ClassSales.java
+++ b/src/main/java/com/linked/classbridge/dto/sales/ClassSales.java
@@ -7,7 +7,9 @@ import lombok.Setter;
 @Getter
 @Setter
 @AllArgsConstructor
-public class MonthlySales {
-    private int month;
-    private int amount;
+public class ClassSales {
+    private Long classId;
+    private String className;
+    private int totalSales;
+
 }

--- a/src/main/java/com/linked/classbridge/dto/sales/TutorSalesResponse.java
+++ b/src/main/java/com/linked/classbridge/dto/sales/TutorSalesResponse.java
@@ -1,22 +1,19 @@
 package com.linked.classbridge.dto.sales;
 
-import com.linked.classbridge.dto.sales.MonthlySales;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@AllArgsConstructor
 public class TutorSalesResponse {
     private Long tutorId;
     private int year;
     private List<MonthlySales> monthlySales;
     private int totalSales;
+//    private List<ClassSales> classSales;
+    private List<ClassMonthlySales> classMonthlySales;
 
-    public TutorSalesResponse(Long tutorId, int year, List<MonthlySales> monthlySales, int totalSales) {
-        this.tutorId = tutorId;
-        this.year = year;
-        this.monthlySales = monthlySales;
-        this.totalSales = totalSales;
-    }
 }

--- a/src/main/java/com/linked/classbridge/dto/tutorPayment/TutorPaymentDetailResponse.java
+++ b/src/main/java/com/linked/classbridge/dto/tutorPayment/TutorPaymentDetailResponse.java
@@ -1,6 +1,7 @@
 package com.linked.classbridge.dto.tutorPayment;
 
 import com.linked.classbridge.domain.TutorPaymentDetail;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -11,11 +12,13 @@ public class TutorPaymentDetailResponse {
     private Long paymentId;
     private int totalAmount;
     private String itemName;
+    private LocalDateTime paymentAt;
 
     public TutorPaymentDetailResponse(TutorPaymentDetail tutorPaymentDetail) {
         this.tutorPaymentDetailId = tutorPaymentDetail.getTutorPaymentDetailId();
         this.paymentId = tutorPaymentDetail.getPayment().getPaymentId();
         this.totalAmount = tutorPaymentDetail.getPayment().getTotalAmount();
         this.itemName = tutorPaymentDetail.getPayment().getItemName();
+        this.paymentAt = tutorPaymentDetail.getPayment().getUpdatedAt();
     }
 }

--- a/src/main/java/com/linked/classbridge/repository/TutorPaymentRepository.java
+++ b/src/main/java/com/linked/classbridge/repository/TutorPaymentRepository.java
@@ -1,6 +1,7 @@
 package com.linked.classbridge.repository;
 
 import com.linked.classbridge.domain.TutorPayment;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +10,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface TutorPaymentRepository extends JpaRepository<TutorPayment, Long> {
     Optional<List<TutorPayment>> findByUserId(Long userId);
+    Optional<List<TutorPayment>> findByUserIdAndPeriodStartDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
+
 }

--- a/src/main/java/com/linked/classbridge/service/KakaoPaymentService.java
+++ b/src/main/java/com/linked/classbridge/service/KakaoPaymentService.java
@@ -91,6 +91,10 @@ public class KakaoPaymentService {
                     .block();// 동기식 처리
 
         } catch (WebClientResponseException e) {
+            log.error("header :: {}", getHeaders());
+            log.error("getHeaders().toSingleValueMap() :: {}", getHeaders().toSingleValueMap());
+            log.error("parameters :: {}", parameters);
+            log.error("url :: {}", payProperties.getReadyUrl());
             throw new RestApiException(ErrorCode.PAY_ERROR);
         }
     }

--- a/src/main/java/com/linked/classbridge/service/SalesService.java
+++ b/src/main/java/com/linked/classbridge/service/SalesService.java
@@ -1,15 +1,22 @@
 package com.linked.classbridge.service;
 
+import com.linked.classbridge.domain.Lesson;
+import com.linked.classbridge.domain.OneDayClass;
 import com.linked.classbridge.domain.Payment;
+import com.linked.classbridge.domain.Reservation;
 import com.linked.classbridge.domain.TutorPayment;
+import com.linked.classbridge.dto.sales.ClassMonthlySales;
 import com.linked.classbridge.dto.sales.MonthlySales;
 import com.linked.classbridge.dto.sales.TutorSalesResponse;
 import com.linked.classbridge.repository.PaymentRepository;
 import com.linked.classbridge.repository.TutorPaymentRepository;
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,6 +29,55 @@ public class SalesService {
     private final TutorPaymentRepository tutorPaymentRepository;
     private final PaymentRepository paymentRepository;
 
+    @Transactional(readOnly = true)
+    public TutorSalesResponse getSalesData(Long tutorId, int year) {
+        List<TutorPayment> pastSettlements = tutorPaymentRepository.findByUserId(tutorId)
+                .orElse(Collections.emptyList());
+
+        YearMonth currentMonth = YearMonth.now();
+        LocalDate currentMonthStart = currentMonth.atDay(1);
+        LocalDate currentMonthEnd = currentMonth.atEndOfMonth();
+
+        List<Payment> currentMonthPayments = paymentRepository.findByUserIdAndPaymentDateTimeBetween(tutorId, currentMonthStart.atStartOfDay(), currentMonthEnd.atTime(23, 59, 59));
+
+        int currentMonthSales = currentMonthPayments.stream().mapToInt(Payment::getTotalAmount).sum();
+
+        List<MonthlySales> monthlySales = pastSettlements.stream()
+                .map(settlement -> new MonthlySales(settlement.getPeriodStartDate().getMonthValue(), settlement.getAmount()))
+                .collect(Collectors.toList());
+
+        monthlySales.add(new MonthlySales(currentMonth.getMonthValue(), currentMonthSales));
+
+        int totalSales = monthlySales.stream().mapToInt(MonthlySales::getAmount).sum();
+
+        Map<Integer, Map<Long, ClassMonthlySales>> monthlyClassSalesMap = new HashMap<>();
+        for (Payment payment : currentMonthPayments) {
+            Reservation reservation = payment.getReservation();
+            if (reservation != null) {
+                Lesson lesson = reservation.getLesson();
+                if (lesson != null) {
+                    OneDayClass oneDayClass = lesson.getOneDayClass();
+                    int month = payment.getUpdatedAt().getMonthValue();
+                    monthlyClassSalesMap.computeIfAbsent(month, k -> new HashMap<>())
+                            .compute(oneDayClass.getClassId(), (classId, classSales) -> {
+                                if (classSales == null) {
+                                    return new ClassMonthlySales(oneDayClass.getClassId(), oneDayClass.getClassName(), month, payment.getTotalAmount());
+                                } else {
+                                    classSales.setAmount(classSales.getAmount() + payment.getTotalAmount());
+                                    return classSales;
+                                }
+                            });
+                }
+            }
+        }
+
+        List<ClassMonthlySales> classMonthlySales = new ArrayList<>();
+        for (Map<Long, ClassMonthlySales> classSalesMap : monthlyClassSalesMap.values()) {
+            classMonthlySales.addAll(classSalesMap.values());
+        }
+
+        return new TutorSalesResponse(tutorId, year, monthlySales, totalSales, classMonthlySales);
+    }
 
 //    public TutorSalesResponse getSalesData(Long tutorId, int year) {
 //        YearMonth startMonth = YearMonth.of(year, 1);
@@ -39,6 +95,7 @@ public class SalesService {
 //        return new TutorSalesResponse(tutorId, year, monthlySales, totalSales);
 //    }
 
+    /*
     @Transactional(readOnly = true)
     public TutorSalesResponse getSalesData(Long tutorId, int year) {
 
@@ -63,4 +120,56 @@ public class SalesService {
 
         return new TutorSalesResponse(tutorId, year, monthlySales, totalSales);
     }
+
+     */
+
+    /*
+    @Transactional(readOnly = true)
+    public TutorSalesResponse getSalesData(Long tutorId, int year) {
+        List<TutorPayment> pastSettlements = tutorPaymentRepository.findByUserId(tutorId)
+                .orElse(Collections.emptyList());
+
+        YearMonth currentMonth = YearMonth.now();
+        LocalDate currentMonthStart = currentMonth.atDay(1);
+        LocalDate currentMonthEnd = currentMonth.atEndOfMonth();
+
+        List<Payment> currentMonthPayments = paymentRepository.findByUserIdAndPaymentDateTimeBetween(tutorId, currentMonthStart.atStartOfDay(), currentMonthEnd.atTime(23, 59, 59));
+
+        int currentMonthSales = currentMonthPayments.stream().mapToInt(Payment::getTotalAmount).sum();
+
+        List<MonthlySales> monthlySales = pastSettlements.stream()
+                .map(settlement -> new MonthlySales(settlement.getPeriodStartDate().getMonthValue(), settlement.getAmount()))
+                .collect(Collectors.toList());
+
+        monthlySales.add(new MonthlySales(currentMonth.getMonthValue(), currentMonthSales));
+
+        int totalSales = monthlySales.stream().mapToInt(MonthlySales::getAmount).sum();
+
+        // Calculate class sales
+        Map<Long, ClassSales> classSalesMap = new HashMap<>();
+        for (Payment payment : currentMonthPayments) {
+            Reservation reservation = payment.getReservation();
+            if (reservation != null) {
+                Lesson lesson = reservation.getLesson();
+                if (lesson != null) {
+                    OneDayClass oneDayClass = lesson.getOneDayClass();
+                    classSalesMap.compute(oneDayClass.getClassId(), (classId, classSales) -> {
+                        if (classSales == null) {
+                            return new ClassSales(oneDayClass.getClassId(), oneDayClass.getClassName(), payment.getTotalAmount());
+                        } else {
+                            classSales.setTotalSales(classSales.getTotalSales() + payment.getTotalAmount());
+                            return classSales;
+                        }
+                    });
+                }
+            }
+        }
+
+        List<ClassSales> classSales = new ArrayList<>(classSalesMap.values());
+
+        return new TutorSalesResponse(tutorId, year, monthlySales, totalSales, classSales);
+    }
+
+     */
+
 }

--- a/src/main/java/com/linked/classbridge/service/TutorPaymentService.java
+++ b/src/main/java/com/linked/classbridge/service/TutorPaymentService.java
@@ -65,13 +65,18 @@ public class TutorPaymentService {
                 });
     }
 
-//    public List<TutorPayment> getTutorPaymentsByUserId(Long userId) {
-//        return tutorPaymentRepository.findByUserId(userId).orElse(Collections.emptyList());
-//    }
-//
-//    public List<TutorPaymentDetail> getTutorPaymentDetails(TutorPayment tutorPayment) {
-//        return tutorPaymentDetailRepository.findByTutorPayment(tutorPayment).orElse(Collections.emptyList());
-//    }
+    @Transactional(readOnly = true)
+    public List<TutorPaymentResponse> getTutorPaymentsByUserIdAndPeriod(Long userId, YearMonth yearMonth) {
+        LocalDate startDate = yearMonth.atDay(1);
+        LocalDate endDate = yearMonth.atEndOfMonth();
+
+        List<TutorPayment> tutorPayments = tutorPaymentRepository.findByUserIdAndPeriodStartDateBetween(userId, startDate, endDate)
+                .orElse(Collections.emptyList());
+
+        return tutorPayments.stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+    }
 
     @Transactional(readOnly = true)
     public List<TutorPaymentResponse> getTutorPaymentsByUserId(Long userId) {

--- a/src/test/http/tutor-payment.http
+++ b/src/test/http/tutor-payment.http
@@ -1,8 +1,14 @@
 ### 정산 목록 조회
 GET http://localhost:8080/api/tutors/payments?userId=1
 Content-Type: application/json
-access: eyJhbGciOiJIUzI1NiJ9.eyJ0b2tlblR5cGUiOiJhY2Nlc3MiLCJlbWFpbCI6InVzZXJ0ZXN0QGV4YW1wbGUuY29tIiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sImlhdCI6MTcxODcwMzUyMywiZXhwIjoxNzE4NzA0MTIzfQ.sdyCl5X-HvMF-5QzgS5C0FvqXO9HuG44pq5OlLswdnc
+access: eyJhbGciOiJIUzI1NiJ9.eyJ0b2tlblR5cGUiOiJhY2Nlc3MiLCJlbWFpbCI6InVzZXJ0ZXN0QGV4YW1wbGUuY29tIiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sImlhdCI6MTcxODk1MzQzOSwiZXhwIjoxNzE4OTU0MDM5fQ.r7LsR97dfLpw9-H513i4bZDR-UROQ2wMFTx_B6bYvIc
+
+### 정산 목록 특정 월 조회
+GET http://localhost:8080/api/tutors/payments?userId=1&yearMonth=2024-04
+Content-Type: application/json
+access: eyJhbGciOiJIUzI1NiJ9.eyJ0b2tlblR5cGUiOiJhY2Nlc3MiLCJlbWFpbCI6InVzZXJ0ZXN0QGV4YW1wbGUuY29tIiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sImlhdCI6MTcxODk1MzQzOSwiZXhwIjoxNzE4OTU0MDM5fQ.r7LsR97dfLpw9-H513i4bZDR-UROQ2wMFTx_B6bYvIc
 
 ### 매출 조회
 GET http://localhost:8080/api/tutors/sales?tutorId=1&year=2024
 Content-Type: application/json
+access: eyJhbGciOiJIUzI1NiJ9.eyJ0b2tlblR5cGUiOiJhY2Nlc3MiLCJlbWFpbCI6InVzZXJ0ZXN0QGV4YW1wbGUuY29tIiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sImlhdCI6MTcxODk1MTk0NSwiZXhwIjoxNzE4OTUyNTQ1fQ.ofb6kP8Dj5SZZYP-slkoJylJBTHW7qkND_q7xfAbd6s


### PR DESCRIPTION
### 요약
월별 쿼리를 지원하도록 정산 시스템을 리팩터링했습니다. 
특정 월별 강사 지급액을 조회하거나 특정 월이 지정되지 않은 경우 모든 지급액을 검색하는 기능이 추가되었습니다.

### 변경사항
컨트롤러: 월별 쿼리에 대해 선택적 yearMonth 매개변수를 허용하도록 getTutorPayments 메소드를 수정했습니다.
서비스: 월별 데이터 검색을 위해 getTutorPaymentsByUserIdAndPeriod 메소드를 구현했습니다.
DTO: 자세한 월별 판매 데이터를 위해 'ClassMonthlySales'를 추가했습니다.
repository: 날짜 범위 내에서 결제를 찾는 방법이 추가되었습니다.

### 요청 예시
모든 정산 조회: GET /api/tutors/payments?userId=1
특정 월에 대한 정산 조회: GET /api/tutors/payments?userId=1&yearMonth=2024-04