### PR TITLE
fix(recommend): change sequence of return image 0 to 1

### DIFF
--- a/src/main/java/com/linked/classbridge/dto/oneDayClass/ClassDto.java
+++ b/src/main/java/com/linked/classbridge/dto/oneDayClass/ClassDto.java
@@ -102,7 +102,7 @@ public class ClassDto {
 
     public void setClassImage(ClassImageRepository classImageRepository) {
 
-        ClassImage classImage = classImageRepository.findFirstByOneDayClassClassIdAndSequence(this.classId, 0)
+        ClassImage classImage = classImageRepository.findFirstByOneDayClassClassIdAndSequence(this.classId, 1)
                 .orElse(null);
         this.classImageUrl = classImage != null ? classImage.getUrl() : null;
     }


### PR DESCRIPTION
### 변경사항
- ClassDto로 추천 클래스 리스트를 반환할 때 클래스 이미지가 null인 현상이 있어서 수정하였습니다.
- ClassDto의 setClassImage 안에서 findFirstByOneDayClassClassIdAndSequence를 사용할 때 sequence가 0이 아닌 1로 설정하였습니다.
<img width="976" alt="스크린샷 2024-06-26 오전 10 46 19" src="https://github.com/ClassBridge/ClassBridge-BE/assets/68321360/abdb84ce-8297-458b-86ee-cb13d7295969">
