### PR TITLE
Feat/#131 search class order end date

### DIFF
--- a/src/main/java/com/linked/classbridge/controller/TutorController.java
+++ b/src/main/java/com/linked/classbridge/controller/TutorController.java
@@ -182,7 +182,7 @@ public class TutorController {
      */
     @Operation(summary = "Class FAQ 추가", description = "Class FAQ 추가")
     @PreAuthorize("hasRole('TUTOR')")
-    @PostMapping(path = "/class/{classId}/faq")
+    @PostMapping(path = "/class/{classId}/faqs")
     public ResponseEntity<SuccessResponse<ClassFAQDto>> registerFAQ(
             @RequestBody @Valid ClassFAQDto request,
             @PathVariable Long classId
@@ -200,7 +200,7 @@ public class TutorController {
      */
     @Operation(summary = "Class FAQ 수정", description = "Class FAQ 수정")
     @PreAuthorize("hasRole('TUTOR')")
-    @PutMapping(path = "/class/{classId}/faq/{faqId}")
+    @PutMapping(path = "/class/{classId}/faqs/{faqId}")
     public ResponseEntity<SuccessResponse<ClassFAQDto>> updateFAQ(
             @RequestBody @Valid ClassFAQDto request,
             @PathVariable Long classId,
@@ -219,7 +219,7 @@ public class TutorController {
      */
     @Operation(summary = "Class FAQ 삭제", description = "Class FAQ 삭제")
     @PreAuthorize("hasRole('TUTOR')")
-    @DeleteMapping(path = "/class/{classId}/faq/{faqId}")
+    @DeleteMapping(path = "/class/{classId}/faqs/{faqId}")
     public ResponseEntity<SuccessResponse<Boolean>> deleteFAQ(
             @PathVariable Long classId,
             @PathVariable Long faqId
@@ -237,7 +237,7 @@ public class TutorController {
      */
     @Operation(summary = "Class lesson 추가", description = "Class lesson 추가")
     @PreAuthorize("hasRole('TUTOR')")
-    @PostMapping(path = "/class/{classId}/lesson")
+    @PostMapping(path = "/class/{classId}/lessons")
     public ResponseEntity<SuccessResponse<LessonDtoDetail>> registerFAQ(
             @RequestBody @Valid LessonDtoDetail.Request request,
             @PathVariable Long classId
@@ -255,7 +255,7 @@ public class TutorController {
      */
     @Operation(summary = "Class lesson 수정", description = "Class lesson 수정")
     @PreAuthorize("hasRole('TUTOR')")
-    @PutMapping(path = "/class/{classId}/lesson/{lessonId}")
+    @PutMapping(path = "/class/{classId}/lessons/{lessonId}")
     public ResponseEntity<SuccessResponse<LessonDtoDetail>> updateLesson(
             @PathVariable Long classId,
             @PathVariable Long lessonId,
@@ -274,7 +274,7 @@ public class TutorController {
      */
     @Operation(summary = "Class lesson 삭제", description = "Class lesson 삭제")
     @PreAuthorize("hasRole('TUTOR')")
-    @DeleteMapping(path = "/class/{classId}/lesson/{lessonId}")
+    @DeleteMapping(path = "/class/{classId}/lessons/{lessonId}")
     public ResponseEntity<SuccessResponse<Boolean>> deleteLesson(
             @PathVariable Long classId,
             @PathVariable Long lessonId
@@ -292,7 +292,7 @@ public class TutorController {
      */
     @Operation(summary = "Class tag 추가", description = "Class tag 추가")
     @PreAuthorize("hasRole('TUTOR')")
-    @PostMapping(path = "/class/{classId}/tag")
+    @PostMapping(path = "/class/{classId}/tags")
     public ResponseEntity<SuccessResponse<ClassTagDto>> registerTag(
             @PathVariable Long classId,
             @RequestBody @Valid ClassTagDto request) {
@@ -309,7 +309,7 @@ public class TutorController {
      */
     @Operation(summary = "Class tag 수정", description = "Class tag 수정")
     @PreAuthorize("hasRole('TUTOR')")
-    @PutMapping(path = "/class/{classId}/tag/{tagId}")
+    @PutMapping(path = "/class/{classId}/tags/{tagId}")
     public ResponseEntity<SuccessResponse<ClassTagDto>> updateTag(
             @PathVariable Long classId,
             @RequestBody @Valid ClassTagDto request,
@@ -327,7 +327,7 @@ public class TutorController {
      */
     @Operation(summary = "Class tag 삭제", description = "Class tag 삭제")
     @PreAuthorize("hasRole('TUTOR')")
-    @DeleteMapping(path = "/class/{classId}/tag/{tagId}")
+    @DeleteMapping(path = "/class/{classId}/tags/{tagId}")
     public ResponseEntity<SuccessResponse<Boolean>> deleteTag(
             @PathVariable Long classId,
             @PathVariable Long tagId ) {

--- a/src/main/java/com/linked/classbridge/service/OneDayClassService.java
+++ b/src/main/java/com/linked/classbridge/service/OneDayClassService.java
@@ -775,18 +775,21 @@ public class OneDayClassService {
         }
 
         if (query != null && !query.isEmpty()) {
-            // className 또는 tutorName이 query와 일치하는 경우
-            BoolQueryBuilder classNameOrTutorName = QueryBuilders.boolQuery()
-                    .should(QueryBuilders.wildcardQuery("className", "*" + query + "*"))
-                    .should(QueryBuilders.wildcardQuery("tutorName", "*" + query + "*"))
-                    .should(QueryBuilders.termQuery("category", query));
+            BoolQueryBuilder className = QueryBuilders.boolQuery()
+                    .must(QueryBuilders.matchPhraseQuery("className", query));
+            BoolQueryBuilder tutorName = QueryBuilders.boolQuery()
+                    .must(QueryBuilders.matchPhraseQuery("tutorName", query));
+            BoolQueryBuilder categoryName = QueryBuilders.boolQuery()
+                    .must(QueryBuilders.matchPhraseQuery("category", query));
 
             // tagList가 query와 정확히 일치하는 경우
             QueryBuilder tagQuery = QueryBuilders.termQuery("tagList", query);
 
             // 최종 쿼리 조합
             BoolQueryBuilder finalQuery = QueryBuilders.boolQuery()
-                    .should(classNameOrTutorName)
+                    .should(className)
+                    .should(tutorName)
+                    .should(categoryName)
                     .should(tagQuery);
 
             queryBuilder.must(finalQuery);

--- a/src/main/java/com/linked/classbridge/service/OneDayClassService.java
+++ b/src/main/java/com/linked/classbridge/service/OneDayClassService.java
@@ -813,6 +813,7 @@ public class OneDayClassService {
                 break;
             case DATE:
                 searchSourceBuilder.sort("endDate", SortOrder.ASC);
+                break;
             default:
                 searchSourceBuilder.sort("totalWish", SortOrder.DESC);
                 break;

--- a/src/main/java/com/linked/classbridge/service/OneDayClassService.java
+++ b/src/main/java/com/linked/classbridge/service/OneDayClassService.java
@@ -195,16 +195,17 @@ public class OneDayClassService {
 
     private List<ClassImage> saveImages(OneDayClass oneDayClass, MultipartFile[] files) {
         List<ClassImage> images = new ArrayList<>();
-
-        for(int i=0; i<files.length; i++) {
-            if(files[i] != null) {
-                String url = s3Service.uploadOneDayClassImage(files[i]);
-                images.add(ClassImage.builder()
-                        .url(url)
-                        .name(files[i].getOriginalFilename())
-                        .sequence(i + 1)
-                        .oneDayClass(oneDayClass)
-                        .build());
+        if(files != null && files.length > 0) {
+            for (int i = 0; i < files.length; i++) {
+                if (files[i] != null) {
+                    String url = s3Service.uploadOneDayClassImage(files[i]);
+                    images.add(ClassImage.builder()
+                            .url(url)
+                            .name(files[i].getOriginalFilename())
+                            .sequence(i + 1)
+                            .oneDayClass(oneDayClass)
+                            .build());
+                }
             }
         }
         return !images.isEmpty() ? classImageRepository.saveAll(images) : new ArrayList<>();
@@ -810,6 +811,8 @@ public class OneDayClassService {
             case STAR:
                 searchSourceBuilder.sort("starRate", SortOrder.DESC);
                 break;
+            case DATE:
+                searchSourceBuilder.sort("endDate", SortOrder.ASC);
             default:
                 searchSourceBuilder.sort("totalWish", SortOrder.DESC);
                 break;


### PR DESCRIPTION
### 변경사항
- 마감 임박 순의 정렬을 추가하였습니다.
- 클래스 생성 시 이미지가 없는 경우도 문제 없이 클래스 등록이 가능하도록 조건문을 추가하였습니다.
- 클래스 검색 시 띄어쓰기가 있는 경우 검색이 되지 않던 부분을 수정하였습니다.
  - 기존 클래스 명 과 강사 명이 should 로 하나로 묶여 있던 것을 각각 분리한 후 must로 검색어가 포함되도록 바꾸었습니다.
  - 기존 검색 설정  
![image](https://github.com/ClassBridge/ClassBridge-BE/assets/30820741/9bf17afd-729a-4edc-9076-1cd0a14d9fa6)
  - 바꾼 후 설정
![image](https://github.com/ClassBridge/ClassBridge-BE/assets/30820741/651d514d-82b1-4a56-9bcf-794e4d1af951)
- mapping의 lesson, tag, faq 를 restful api 에 맞는 복수형 lessons, tags, faqs 로 바꾸어주었습니다.

### 테스트
- [x] API 테스트 