### PR TITLE
refactor: wish delete with classId

### DIFF
--- a/src/main/java/com/linked/classbridge/controller/UserController.java
+++ b/src/main/java/com/linked/classbridge/controller/UserController.java
@@ -29,7 +29,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -214,13 +213,13 @@ public class UserController {
 
     @Operation(summary = "수강생 찜목록 삭제", description = "수강생 찜목록 삭제")
     @PreAuthorize("hasRole('USER')")
-    @DeleteMapping("/wish/{wishId}")
+    @DeleteMapping("/wish")
     public ResponseEntity<SuccessResponse<Boolean>> deleteWish(
-            @PathVariable Long wishId) {
+            @RequestBody WishDto.Request request) {
         return ResponseEntity.ok().body(
                 SuccessResponse.of(
                         ResponseMessage.WISH_DELETE_SUCCESS,
-                        userService.deleteWish(userService.getCurrentUserEmail(), wishId)
+                        userService.deleteWish(userService.getCurrentUserEmail(), request.classId())
                 )
         );
     }

--- a/src/main/java/com/linked/classbridge/repository/WishRepository.java
+++ b/src/main/java/com/linked/classbridge/repository/WishRepository.java
@@ -2,10 +2,13 @@ package com.linked.classbridge.repository;
 
 import com.linked.classbridge.domain.Wish;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WishRepository extends JpaRepository<Wish, Long> {
     List<Wish> findByUserUserId(Long userId);
 
     boolean existsByUserUserIdAndOneDayClassClassId(Long userId, Long classId);
+
+    Optional<Wish> findByUserUserIdAndOneDayClassClassId(Long userId,Long classId);
 }

--- a/src/main/java/com/linked/classbridge/service/UserService.java
+++ b/src/main/java/com/linked/classbridge/service/UserService.java
@@ -397,9 +397,9 @@ public class UserService {
         return true;
     }
 
-    public Boolean deleteWish(String email, Long wishId) {
+    public Boolean deleteWish(String email, Long classId) {
         User user = userRepository.findByEmail(email).orElseThrow(() -> new RestApiException(USER_NOT_FOUND));
-        Wish wish = wishRepository.findById(wishId).orElseThrow(() -> new RestApiException(WISH_NOT_FOUND));
+        Wish wish = wishRepository.findByUserUserIdAndOneDayClassClassId(user.getUserId(), classId).orElseThrow(() -> new RestApiException(WISH_NOT_FOUND));
         OneDayClass oneDayClass = oneDayClassRepository.findById(wish.getOneDayClass().getClassId()).orElseThrow(() -> new RestApiException(CLASS_NOT_FOUND));
 
         if(!Objects.equals(user.getUserId(), wish.getUser().getUserId())) {


### PR DESCRIPTION
### 변경사항
- 기존 wish delete 는 wishId 로 삭제를 시켰는데, 프론트에서 메인 페이지 같은 곳에서는 wishId를 반환받지 못하기 때문에 classId로 요청을 보내는 것으로 변경하였습니다.
- /api/users/wish/{wishId} 에서 /api/users/wish 로 변경되었습니다. 또한 body에 classId를 넣어주는 것으로 변경되었습니다.

### 테스트
- [x] API 테스트 
![image](https://github.com/ClassBridge/ClassBridge-BE/assets/30820741/d236a57b-b67f-4920-81a3-a13866dd8744)
