### PR TITLE
fix: set total reviews in oneDayClassDocument

### DIFF
--- a/src/main/java/com/linked/classbridge/repository/LessonRepository.java
+++ b/src/main/java/com/linked/classbridge/repository/LessonRepository.java
@@ -23,14 +23,15 @@ public interface LessonRepository extends JpaRepository<Lesson, Long> {
 
     boolean existsByOneDayClassClassIdAndLessonDateIsBetweenAndParticipantNumberIsGreaterThan(long classId, LocalDate startDate, LocalDate changeStartDate,
                                                                                               int zero);
-
     List<Lesson> findAllByOneDayClassClassIdAndLessonDateIsAfter(long classId, LocalDate localDate);
 
     boolean existsByOneDayClassClassIdAndParticipantNumberIsGreaterThanAndLessonDateIsAfter(long classId, int personal, LocalDate now);
 
-    List<Lesson> findAllByOneDayClassClassId(long classId);
-
     boolean existsByOneDayClassClassIdAndLessonDateAndStartTime(Long classId, LocalDate localDate, LocalTime localTime);
 
     boolean existsByOneDayClassClassIdAndLessonDateIsAfterAndParticipantNumberIsLessThan(Long classId, LocalDate localDate, int personal);
+
+    List<Lesson> findAllByOneDayClassClassIdAndLessonDateIsAfterOrderByLessonDateAscStartTimeAsc(long classId, LocalDate localDate);
+
+    List<Lesson> findAllByOneDayClassClassIdOrderByLessonDateAscStartTimeAsc(long classId);
 }

--- a/src/main/java/com/linked/classbridge/service/OneDayClassService.java
+++ b/src/main/java/com/linked/classbridge/service/OneDayClassService.java
@@ -468,7 +468,7 @@ public class OneDayClassService {
         User tutor = getUser(email);
         validateOneDayClassMatchTutor(tutor, oneDayClass);
 
-        oneDayClass.setLessonList(lessonRepository.findAllByOneDayClassClassId(classId));
+        oneDayClass.setLessonList(lessonRepository.findAllByOneDayClassClassIdOrderByLessonDateAscStartTimeAsc(classId));
         oneDayClass.setTagList(tagRepository.findAllByOneDayClassClassId(classId));
         oneDayClass.setFaqList(faqRepository.findAllByOneDayClassClassId(classId));
         oneDayClass.setImageList(imageRepository.findAllByOneDayClassClassIdOrderBySequence(classId));
@@ -481,7 +481,7 @@ public class OneDayClassService {
         boolean isWish = false;
         boolean isWanted = false;
 
-        oneDayClass.setLessonList(lessonRepository.findAllByOneDayClassClassIdAndLessonDateIsAfter(classId, LocalDate.now().minusDays(1)));
+        oneDayClass.setLessonList(lessonRepository.findAllByOneDayClassClassIdAndLessonDateIsAfterOrderByLessonDateAscStartTimeAsc(classId, LocalDate.now().minusDays(1)));
         oneDayClass.setTagList(tagRepository.findAllByOneDayClassClassId(classId));
         oneDayClass.setFaqList(faqRepository.findAllByOneDayClassClassId(classId));
         oneDayClass.setImageList(imageRepository.findAllByOneDayClassClassIdOrderBySequence(classId));

--- a/src/main/java/com/linked/classbridge/service/ReviewService.java
+++ b/src/main/java/com/linked/classbridge/service/ReviewService.java
@@ -287,6 +287,7 @@ public class ReviewService {
                 .orElseThrow(() -> new RestApiException(CLASS_NOT_FOUND));
         oneDayClassDocument.setStarRate(oneDayClass.getTotalStarRate() / (oneDayClass.getTotalReviews() == 0 ? 1
                 : oneDayClass.getTotalReviews()));
+        oneDayClassDocument.setTotalReviews(oneDayClass.getTotalReviews());
         operations.save(oneDayClassDocument);
     }
 }

--- a/src/main/java/com/linked/classbridge/service/ReviewService.java
+++ b/src/main/java/com/linked/classbridge/service/ReviewService.java
@@ -285,7 +285,7 @@ public class ReviewService {
     private void updateOneDayClassDocumentStarRate(OneDayClass oneDayClass) {
         OneDayClassDocument oneDayClassDocument = oneDayClassDocumentRepository.findById(oneDayClass.getClassId())
                 .orElseThrow(() -> new RestApiException(CLASS_NOT_FOUND));
-        oneDayClassDocument.setStarRate(oneDayClass.getTotalStarRate() / (oneDayClass.getTotalReviews() == 0 ? 1
+        oneDayClassDocument.setStarRate(oneDayClass.getTotalStarRate() / (double)(oneDayClass.getTotalReviews() == 0 ? 1
                 : oneDayClass.getTotalReviews()));
         oneDayClassDocument.setTotalReviews(oneDayClass.getTotalReviews());
         operations.save(oneDayClassDocument);


### PR DESCRIPTION
### 변경사항
- openSearch에 save할 때 총 리뷰 개수가 반영하는 라인을 추가하였습니다.
- 클래스 상세보기에서 레슨 리스트를 lessonDate와 startTime 으로 정렬하도록 변경하였습니다.

### 테스트
- [x] API 테스트 