### PR TITLE
fix(chatroom): fix create chat room by user id

### DIFF
--- a/src/main/java/com/linked/classbridge/controller/ChatRoomController.java
+++ b/src/main/java/com/linked/classbridge/controller/ChatRoomController.java
@@ -5,10 +5,8 @@ import com.linked.classbridge.dto.SuccessResponse;
 import com.linked.classbridge.dto.chat.CreateChatRoom;
 import com.linked.classbridge.dto.chat.GetChatRoomsResponse;
 import com.linked.classbridge.dto.chat.JoinChatRoom;
-import com.linked.classbridge.exception.RestApiException;
 import com.linked.classbridge.service.UserService;
 import com.linked.classbridge.service.chat.ChatService;
-import com.linked.classbridge.type.ErrorCode;
 import com.linked.classbridge.type.ResponseMessage;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -35,14 +33,12 @@ public class ChatRoomController {
     public ResponseEntity<SuccessResponse<CreateChatRoom.Response>> createChatRoom(
             @Valid @RequestBody CreateChatRoom.Request request
     ) {
-
-        User user = userService.findByEmail(userService.getCurrentUserEmail())
-                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
+        User user = userService.getCurrentUser();
         // 채팅방 생성
         return ResponseEntity.ok().body(
                 SuccessResponse.of(
                         ResponseMessage.CHAT_ROOM_CREATE_SUCCESS,
-                        chatService.createChatRoomProcess(user, request.classId())
+                        chatService.createChatRoomProcess(user, request.userId())
                 )
         );
     }
@@ -52,8 +48,7 @@ public class ChatRoomController {
     public ResponseEntity<SuccessResponse<JoinChatRoom.Response>> joinChatRoom(
             @PathVariable Long chatRoomId
     ) {
-        User user = userService.findByEmail(userService.getCurrentUserEmail())
-                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
+        User user = userService.getCurrentUser();
         // 채팅방 참여
         return ResponseEntity.ok().body(
                 SuccessResponse.of(
@@ -68,8 +63,7 @@ public class ChatRoomController {
     public ResponseEntity<SuccessResponse<String>> leaveChatRoom(
             @PathVariable Long chatRoomId
     ) {
-        User user = userService.findByEmail(userService.getCurrentUserEmail())
-                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
+        User user = userService.getCurrentUser();
         // 채팅방 나가기
         chatService.closeChatRoomProcess(user, chatRoomId);
         return ResponseEntity.ok().body(SuccessResponse.of(ResponseMessage.CHAT_ROOM_CLOSE_SUCCESS));
@@ -80,8 +74,7 @@ public class ChatRoomController {
     public ResponseEntity<SuccessResponse<String>> deleteChatRoom(
             @PathVariable Long chatRoomId
     ) {
-        User user = userService.findByEmail(userService.getCurrentUserEmail())
-                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
+        User user = userService.getCurrentUser();
         // 채팅방 삭제
         chatService.leaveChatRoomProcess(user, chatRoomId);
         return ResponseEntity.ok().body(SuccessResponse.of(ResponseMessage.CHAT_ROOM_LEAVE_SUCCESS));
@@ -90,9 +83,7 @@ public class ChatRoomController {
     @Operation(summary = "채팅방 목록 조회", description = "채팅방 목록을 조회합니다.")
     @GetMapping
     public ResponseEntity<SuccessResponse<GetChatRoomsResponse>> getChatRooms() {
-        User user = userService.findByEmail(userService.getCurrentUserEmail())
-                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
-
+        User user = userService.getCurrentUser();
         return ResponseEntity.ok().body(SuccessResponse.of(chatService.getChatRoomListProcess(user)));
     }
 }

--- a/src/main/java/com/linked/classbridge/domain/UserChatRoom.java
+++ b/src/main/java/com/linked/classbridge/domain/UserChatRoom.java
@@ -44,6 +44,9 @@ public class UserChatRoom extends BaseEntity {
     @Builder.Default
     private boolean isOnline = false;
 
+    @Builder.Default
+    private boolean isDeleted = false;
+
     public void setOnline() {
         this.isOnline = true;
     }

--- a/src/main/java/com/linked/classbridge/dto/chat/CreateChatRoom.java
+++ b/src/main/java/com/linked/classbridge/dto/chat/CreateChatRoom.java
@@ -7,9 +7,9 @@ import jakarta.validation.constraints.NotNull;
 public class CreateChatRoom {
 
     public record Request(
-            @Schema(description = "문의할 클래스 ID", example = "1")
-            @NotNull(message = "클래스 ID는 필수 입력 값입니다.")
-            Long classId
+            @Schema(description = "채팅 상대 유저 ID", example = "1")
+            @NotNull(message = "유저 ID는 필수 입력 값입니다.")
+            Long userId
     ) {
 
     }

--- a/src/main/java/com/linked/classbridge/service/KakaoPaymentService.java
+++ b/src/main/java/com/linked/classbridge/service/KakaoPaymentService.java
@@ -20,7 +20,6 @@ import com.linked.classbridge.dto.payment.PaymentPrepareDto.Request;
 import com.linked.classbridge.dto.payment.PaymentPrepareDto.Response;
 import com.linked.classbridge.exception.RestApiException;
 import com.linked.classbridge.repository.LessonRepository;
-import com.linked.classbridge.repository.OneDayClassRepository;
 import com.linked.classbridge.repository.PaymentRepository;
 import com.linked.classbridge.repository.ReservationRepository;
 import com.linked.classbridge.type.ErrorCode;
@@ -59,7 +58,6 @@ public class KakaoPaymentService {
     private final LessonRepository lessonRepository;
     private final LessonService lessonService;
     private final UserService userService;
-    private final OneDayClassRepository classRepository;
 
     @Value("${baseUrl}")
     private String baseUrl;
@@ -167,11 +165,14 @@ public class KakaoPaymentService {
 //            return entity.block();
             ResponseEntity<String> result = entity.block();
 
-            OneDayClass oneDayClass = reservationRepository.findOneDayClassById(response.getReservationId()).orElseThrow(() -> new RestApiException(CLASS_NOT_FOUND));
+            OneDayClass oneDayClass = reservationRepository.findOneDayClassById(response.getReservationId())
+                    .orElseThrow(() -> new RestApiException(CLASS_NOT_FOUND));
             log.info("classId {}, reservationId {}", oneDayClass.getClassId(), response.getReservationId());
             // 성공 후 리디렉션 URL 반환
             return ResponseEntity.status(HttpStatus.FOUND)
-                    .header(HttpHeaders.LOCATION, "https://class-bridge.vercel.app/redirect?type=payment&success=true&reservationId=" + response.getReservationId() + "&classId=" + oneDayClass.getClassId())
+                    .header(HttpHeaders.LOCATION,
+                            "https://class-bridge.vercel.app/redirect?type=payment&success=true&reservationId="
+                                    + response.getReservationId() + "&classId=" + oneDayClass.getClassId())
                     .body("Redirecting to payment success page");
 
         } catch (WebClientResponseException e) {
@@ -249,11 +250,12 @@ public class KakaoPaymentService {
         parameters.put("quantity", Integer.toString(request.getQuantity()));
         parameters.put("total_amount", Integer.toString(request.getTotalAmount()));
         parameters.put("tax_free_amount", Integer.toString(request.getTexFreeAmount()));
-        parameters.put("approval_url", baseUrl+"/api/payments/complete"); // 성공 시 redirect url
+        parameters.put("approval_url", baseUrl + "/api/payments/complete"); // 성공 시 redirect url
 //        parameters.put("approval_url", "https://class-bridge.vercel.app/redirect?type=payment&success=true"); // 성공 시 redirect url
-        parameters.put("cancel_url", baseUrl+"/api/payments/cancel"); // 취소 시 redirect url
+        parameters.put("cancel_url", baseUrl + "/api/payments/cancel"); // 취소 시 redirect url
 //        parameters.put("fail_url", baseUrl+"/api/payments/fail"); // 실패 시 redirect url
-        parameters.put("fail_url", "https://class-bridge.vercel.app/redirect?type=payment&success=false"); // 실패 시 redirect url
+        parameters.put("fail_url",
+                "https://class-bridge.vercel.app/redirect?type=payment&success=false"); // 실패 시 redirect url
 
         return parameters;
     }

--- a/src/main/java/com/linked/classbridge/service/UserService.java
+++ b/src/main/java/com/linked/classbridge/service/UserService.java
@@ -83,10 +83,12 @@ public class UserService {
     private final OneDayClassDocumentRepository oneDayClassDocumentRepository;
     private final ElasticsearchOperations operations;
 
-    public UserService(UserRepository userRepository, CategoryRepository categoryRepository, PasswordEncoder passwordEncoder,
+    public UserService(UserRepository userRepository, CategoryRepository categoryRepository,
+                       PasswordEncoder passwordEncoder,
                        JWTService jwtService, S3Service s3Service, OneDayClassRepository oneDayClassRepository,
                        WishRepository wishRepository, ClassImageRepository classImageRepository,
-                       OneDayClassDocumentRepository oneDayClassDocumentRepository, ElasticsearchOperations operations) {
+                       OneDayClassDocumentRepository oneDayClassDocumentRepository,
+                       ElasticsearchOperations operations) {
 
         this.userRepository = userRepository;
         this.categoryRepository = categoryRepository;
@@ -104,7 +106,7 @@ public class UserService {
 
         log.info("Checking if nickname '{}' exists", nickname);
 
-        if(userRepository.existsByNickname(nickname)){
+        if (userRepository.existsByNickname(nickname)) {
             log.warn("Nickname '{}' already exists", nickname);
             throw new RestApiException(ALREADY_EXIST_NICKNAME);
         }
@@ -117,7 +119,7 @@ public class UserService {
 
         log.info("Checking if email '{}' exists", email);
 
-        if(userRepository.existsByEmail(email)){
+        if (userRepository.existsByEmail(email)) {
             log.warn("Email '{}' is already registered", email);
             throw new RestApiException(ALREADY_REGISTERED_EMAIL);
         }
@@ -191,7 +193,7 @@ public class UserService {
             throw new RestApiException(ALREADY_REGISTERED_EMAIL);
         }
 
-        if(userRepository.existsByNickname(additionalInfoDto.getNickname())) {
+        if (userRepository.existsByNickname(additionalInfoDto.getNickname())) {
             log.warn("Nickname '{}' already exists", additionalInfoDto.getNickname());
             throw new RestApiException(ALREADY_EXIST_NICKNAME);
         }
@@ -202,7 +204,9 @@ public class UserService {
 
         List<UserRole> roles = new ArrayList<>();
         roles.add(UserRole.ROLE_USER);
-        Gender gender = additionalInfoDto.getGender() != null ? Gender.valueOf(additionalInfoDto.getGender().toUpperCase()) : null;
+        Gender gender =
+                additionalInfoDto.getGender() != null ? Gender.valueOf(additionalInfoDto.getGender().toUpperCase())
+                        : null;
 
         // 관심 카테고리 String -> Category 변환
         List<Category> interests = additionalInfoDto.getInterests().stream()
@@ -229,14 +233,16 @@ public class UserService {
             user.setProfileImageUrl(profileImageUrl);
         }
 
-        if(signupRequest.getUserDto().getPassword() != null) {
+        if (signupRequest.getUserDto().getPassword() != null) {
             user.setPassword(passwordEncoder.encode(signupRequest.getUserDto().getPassword()));
         }
         userRepository.save(user);
         log.info("User '{}' added successfully", user.getUsername());
 
-        String access = jwtService.createJwt(TokenType.ACCESS.getValue(), user.getEmail(), userDto.getRoles(), TokenType.ACCESS.getExpiryTime());
-        String refresh = jwtService.createJwt(TokenType.REFRESH.getValue(), user.getEmail(), userDto.getRoles(), TokenType.REFRESH.getExpiryTime());
+        String access = jwtService.createJwt(TokenType.ACCESS.getValue(), user.getEmail(), userDto.getRoles(),
+                TokenType.ACCESS.getExpiryTime());
+        String refresh = jwtService.createJwt(TokenType.REFRESH.getValue(), user.getEmail(), userDto.getRoles(),
+                TokenType.REFRESH.getExpiryTime());
         // JWT 토큰을 클라이언트로 전송
         HttpServletResponse response = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getResponse();
         if (response != null) {
@@ -265,8 +271,10 @@ public class UserService {
                 .map(Enum::name)
                 .collect(Collectors.toList());
 
-        String access = jwtService.createJwt(TokenType.ACCESS.getValue(), user.getEmail(), roles, TokenType.ACCESS.getExpiryTime());
-        String refresh = jwtService.createJwt(TokenType.REFRESH.getValue(), user.getEmail(), roles, TokenType.REFRESH.getExpiryTime());
+        String access = jwtService.createJwt(TokenType.ACCESS.getValue(), user.getEmail(), roles,
+                TokenType.ACCESS.getExpiryTime());
+        String refresh = jwtService.createJwt(TokenType.REFRESH.getValue(), user.getEmail(), roles,
+                TokenType.REFRESH.getExpiryTime());
         // JWT 토큰을 클라이언트로 전송
         HttpServletResponse response = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getResponse();
         if (response != null) {
@@ -287,7 +295,7 @@ public class UserService {
                     return new RestApiException(USER_NOT_FOUND);
                 });
 
-        if(additionalInfoDto == null && profileImage == null) {
+        if (additionalInfoDto == null && profileImage == null) {
             log.warn("No information to update");
             throw new RestApiException(NO_INFORMATION_TO_UPDATE);
         }
@@ -302,9 +310,12 @@ public class UserService {
                 user.setNickname(additionalInfoDto.getNickname());
             }
 
-            user.setPhone(additionalInfoDto.getPhoneNumber() != null ? additionalInfoDto.getPhoneNumber() : user.getPhone());
-            user.setGender(additionalInfoDto.getGender() != null ? Gender.valueOf(additionalInfoDto.getGender()) : user.getGender());
-            user.setBirthDate(additionalInfoDto.getBirthDate() != null ? additionalInfoDto.getBirthDate() : user.getBirthDate());
+            user.setPhone(
+                    additionalInfoDto.getPhoneNumber() != null ? additionalInfoDto.getPhoneNumber() : user.getPhone());
+            user.setGender(additionalInfoDto.getGender() != null ? Gender.valueOf(additionalInfoDto.getGender())
+                    : user.getGender());
+            user.setBirthDate(
+                    additionalInfoDto.getBirthDate() != null ? additionalInfoDto.getBirthDate() : user.getBirthDate());
 
             if (additionalInfoDto.getInterests() != null) {
                 List<Category> interests = additionalInfoDto.getInterests().stream()
@@ -357,7 +368,8 @@ public class UserService {
 
         Page<OneDayClass> classList = oneDayClassRepository.findAllByClassIdIn(classIdList, pageable);
 
-        Map<Long, String> imageMap = (classImageRepository.findAllByOneDayClassClassIdInAndSequence(classList.map(OneDayClass::getClassId).toList(), 1))
+        Map<Long, String> imageMap = (classImageRepository.findAllByOneDayClassClassIdInAndSequence(
+                classList.map(OneDayClass::getClassId).toList(), 1))
                 .stream().collect(Collectors.toMap(
                         classImage -> classImage.getOneDayClass().getClassId(),
                         ClassImage::getUrl
@@ -366,7 +378,7 @@ public class UserService {
         Page<WishDto> wishDtoPage = classList.map(WishDto::new);
         wishDtoPage.forEach(item -> {
             item.setWishId(wishMap.get(item.getClassId()));
-            if(imageMap.containsKey(item.getClassId())) {
+            if (imageMap.containsKey(item.getClassId())) {
                 item.setClassImageUrl(imageMap.get(item.getClassId()));
             }
         });
@@ -376,13 +388,14 @@ public class UserService {
 
     public Boolean addWish(String email, Long classId) {
         User user = userRepository.findByEmail(email).orElseThrow(() -> new RestApiException(USER_NOT_FOUND));
-        OneDayClass oneDayClass = oneDayClassRepository.findById(classId).orElseThrow(() -> new RestApiException(CLASS_NOT_FOUND));
+        OneDayClass oneDayClass = oneDayClassRepository.findById(classId)
+                .orElseThrow(() -> new RestApiException(CLASS_NOT_FOUND));
 
-        if(Objects.equals(user.getUserId(), oneDayClass.getTutor().getUserId())) {
+        if (Objects.equals(user.getUserId(), oneDayClass.getTutor().getUserId())) {
             throw new RestApiException(CANNOT_ADD_WISH_OWN_CLASS);
         }
 
-        if(wishRepository.existsByUserUserIdAndOneDayClassClassId(user.getUserId(), oneDayClass.getClassId())) {
+        if (wishRepository.existsByUserUserIdAndOneDayClassClassId(user.getUserId(), oneDayClass.getClassId())) {
             throw new RestApiException(EXISTS_WISH_CLASS);
         }
 
@@ -400,10 +413,12 @@ public class UserService {
 
     public Boolean deleteWish(String email, Long classId) {
         User user = userRepository.findByEmail(email).orElseThrow(() -> new RestApiException(USER_NOT_FOUND));
-        Wish wish = wishRepository.findByUserUserIdAndOneDayClassClassId(user.getUserId(), classId).orElseThrow(() -> new RestApiException(WISH_NOT_FOUND));
-        OneDayClass oneDayClass = oneDayClassRepository.findById(wish.getOneDayClass().getClassId()).orElseThrow(() -> new RestApiException(CLASS_NOT_FOUND));
+        Wish wish = wishRepository.findByUserUserIdAndOneDayClassClassId(user.getUserId(), classId)
+                .orElseThrow(() -> new RestApiException(WISH_NOT_FOUND));
+        OneDayClass oneDayClass = oneDayClassRepository.findById(wish.getOneDayClass().getClassId())
+                .orElseThrow(() -> new RestApiException(CLASS_NOT_FOUND));
 
-        if(!Objects.equals(user.getUserId(), wish.getUser().getUserId())) {
+        if (!Objects.equals(user.getUserId(), wish.getUser().getUserId())) {
             throw new RestApiException(MISMATCH_USER_WISH);
         }
 
@@ -418,7 +433,8 @@ public class UserService {
     }
 
     private void updateOneDayClassDocumentTotalWish(OneDayClass oneDayClass) {
-        OneDayClassDocument oneDayClassDocument = oneDayClassDocumentRepository.findById(oneDayClass.getClassId()).orElseThrow(() -> new RestApiException(CLASS_NOT_FOUND));
+        OneDayClassDocument oneDayClassDocument = oneDayClassDocumentRepository.findById(oneDayClass.getClassId())
+                .orElseThrow(() -> new RestApiException(CLASS_NOT_FOUND));
         oneDayClassDocument.setTotalWish(oneDayClass.getTotalWish());
         operations.save(oneDayClassDocument);
     }
@@ -432,5 +448,13 @@ public class UserService {
         User user = getUserByEmail(getCurrentUserEmail());
 
         return new UserInfoDto(user);
+    }
+
+    public User findUserById(Long userId) {
+        return userRepository.findById(userId).orElseThrow(() -> new RestApiException(USER_NOT_FOUND));
+    }
+
+    public User getCurrentUser() {
+        return getUserByEmail(getCurrentUserEmail());
     }
 }

--- a/src/main/java/com/linked/classbridge/service/chat/ChatService.java
+++ b/src/main/java/com/linked/classbridge/service/chat/ChatService.java
@@ -16,7 +16,6 @@ import com.linked.classbridge.dto.chat.JoinChatRoom;
 import com.linked.classbridge.dto.chat.ReadReceipt;
 import com.linked.classbridge.dto.chat.ReadReceiptList;
 import com.linked.classbridge.exception.RestApiException;
-import com.linked.classbridge.service.OneDayClassService;
 import com.linked.classbridge.service.UserService;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -40,16 +39,14 @@ public class ChatService {
 
     private final MessageSendingService messageSendingService;
 
-    private final OneDayClassService oneDayClassService;
-
     // 채팅방 생성
-    public CreateChatRoom.Response createChatRoomProcess(User initiatedBy, Long classId) {
-        log.info("Create chat room initiated by user: {}", initiatedBy.getUserId());
-        User initiatedTo = oneDayClassService.findClassById(classId).getTutor();
+    public CreateChatRoom.Response createChatRoomProcess(User chatStartUser, Long chatPartnerId) {
+        log.info("Create chat room initiated by user: {}", chatStartUser.getUserId());
+        User chatPartner = userService.findUserById(chatPartnerId);
 
-        validateChatRoomInitiation(initiatedBy, initiatedTo);
+        validateChatRoomInitiation(chatStartUser, chatPartner);
 
-        ChatRoom chatRoom = chatRoomService.createOrFindChatRoomByUsers(initiatedBy, initiatedTo);
+        ChatRoom chatRoom = chatRoomService.createOrFindChatRoomByUsers(chatStartUser, chatPartner);
 
         log.info("Chat room created: {}", chatRoom.getChatRoomId());
         return CreateChatRoom.Response.fromEntity(chatRoom);

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,9 +22,9 @@ spring:
     open-in-view: false
     properties:
       hibernate:
-        show-sql: true
-        format_sql: true
-        use_sql_comments: true
+        show-sql: false
+        #        format_sql: true
+        #        use_sql_comments: true
         jdbc:
           time_zone: UTC
   security:

--- a/src/test/java/com/linked/classbridge/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/linked/classbridge/controller/ChatRoomControllerTest.java
@@ -26,7 +26,6 @@ import com.linked.classbridge.service.chat.ChatService;
 import com.linked.classbridge.type.ErrorCode;
 import com.linked.classbridge.type.ResponseMessage;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -79,8 +78,7 @@ class ChatRoomControllerTest {
 
         createChatRoomRequest = new Request(1L);
 
-        given(userService.findByEmail(userService.getCurrentUserEmail()))
-                .willReturn(Optional.of(mockUser));
+        given(userService.getCurrentUser()).willReturn(mockUser);
     }
 
     @Test
@@ -90,8 +88,7 @@ class ChatRoomControllerTest {
         // given
         CreateChatRoom.Response response = new CreateChatRoom.Response(1L, "/chatRooms/1");
 
-        given(chatService.createChatRoomProcess(mockUser, createChatRoomRequest.classId()))
-                .willReturn(response);
+        given(chatService.createChatRoomProcess(mockUser, createChatRoomRequest.userId())).willReturn(response);
 
         // when & then
         mockMvc.perform(post("/api/chatRooms")
@@ -113,7 +110,7 @@ class ChatRoomControllerTest {
     @DisplayName("채팅방 생성 실패 - 나의 클래스일 경우")
     void createChatRoom_fail_request_to_my_class() throws Exception {
         // given
-        given(chatService.createChatRoomProcess(mockUser, createChatRoomRequest.classId()))
+        given(chatService.createChatRoomProcess(mockUser, createChatRoomRequest.userId()))
                 .willThrow(new RestApiException(BAD_REQUEST));
 
         // when & then
@@ -209,7 +206,7 @@ class ChatRoomControllerTest {
                 .userId(user.getUserId())
                 .build();
         getChatRoomsResponse.addChatRoomInfo(chatRoom1, partner, chatRoomUnreadCountInfoDto);
-        given(userService.findByEmail(userService.getCurrentUserEmail())).willReturn(Optional.of(user));
+        given(userService.getCurrentUser()).willReturn(user);
         given(chatService.getChatRoomListProcess(user)).willReturn(getChatRoomsResponse);
 
         // when & then

--- a/src/test/java/com/linked/classbridge/service/chat/ChatServiceTest.java
+++ b/src/test/java/com/linked/classbridge/service/chat/ChatServiceTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.when;
 
 import com.linked.classbridge.domain.ChatMessage;
 import com.linked.classbridge.domain.ChatRoom;
-import com.linked.classbridge.domain.OneDayClass;
 import com.linked.classbridge.domain.User;
 import com.linked.classbridge.domain.UserChatRoom;
 import com.linked.classbridge.dto.chat.ChatRoomUnreadCountInfoDto;
@@ -24,7 +23,6 @@ import com.linked.classbridge.dto.chat.JoinChatRoom;
 import com.linked.classbridge.dto.chat.ReadReceipt;
 import com.linked.classbridge.dto.chat.ReadReceiptList;
 import com.linked.classbridge.exception.RestApiException;
-import com.linked.classbridge.service.OneDayClassService;
 import com.linked.classbridge.service.UserService;
 import com.linked.classbridge.type.ErrorCode;
 import java.time.LocalDateTime;
@@ -53,9 +51,6 @@ class ChatServiceTest {
     private UserChatRoomService userChatRoomService;
     @Mock
     private MessageSendingService messageSendingService;
-    @Mock
-    private OneDayClassService oneDayClassService;
-
     private User user;
     private User tutor;
     private User otherUser;
@@ -66,7 +61,6 @@ class ChatServiceTest {
     private ChatMessage chatMessage1;
     private ChatMessage chatMessage2;
     private ChatMessage chatMessage3;
-    private OneDayClass oneDayClass;
 
     @BeforeEach
     void setUp() {
@@ -109,10 +103,6 @@ class ChatServiceTest {
                 .sendTime(LocalDateTime.of(2024, 1, 1, 0, 2))
                 .isRead(false)
                 .build();
-        oneDayClass = OneDayClass.builder()
-                .classId(1L)
-                .tutor(tutor)
-                .build();
 
         userChatRoom1 = UserChatRoom.builder()
                 .user(user)
@@ -132,13 +122,12 @@ class ChatServiceTest {
     @Test
     void createChatRoomProcess() {
         // given
-        Long classId = 1L;
-
-        given(oneDayClassService.findClassById(classId)).willReturn(oneDayClass);
+        Long chatPartnerId = 2L;
+        given(userService.findUserById(chatPartnerId)).willReturn(tutor);
         given(chatRoomService.createOrFindChatRoomByUsers(user, tutor)).willReturn(chatRoom1);
 
         // when
-        CreateChatRoom.Response createChatRoom = chatService.createChatRoomProcess(user, classId);
+        CreateChatRoom.Response createChatRoom = chatService.createChatRoomProcess(user, chatPartnerId);
 
         // then
         assertEquals(chatRoom1.getChatRoomId(), createChatRoom.chatRoomId());
@@ -147,12 +136,12 @@ class ChatServiceTest {
     @Test
     void createChatRoomProcessInitiatedToMyself() {
         // given
-        Long classId = 1L;
-        given(oneDayClassService.findClassById(classId)).willReturn(oneDayClass);
+        Long chatPartnerId = 2L;
+        given(userService.findUserById(chatPartnerId)).willReturn(tutor);
 
         // when
         RestApiException exception = assertThrows(RestApiException.class,
-                () -> chatService.createChatRoomProcess(tutor, classId));
+                () -> chatService.createChatRoomProcess(tutor, chatPartnerId));
 
         // then
         assertEquals(ErrorCode.BAD_REQUEST, exception.getErrorCode());


### PR DESCRIPTION
### 변경사항

**AS-IS**

채팅방 생성 요청 시 class id를 바디에 담는 방식으로 해당 클래스의 강사와의 1:1 채팅방을 생성
따라서 유저 -> 강사로의 채팅방 생성 요청만 가능했었음

**TO-BE**

채팅방 생서 요청 시 user id를 바디에 담는 방식으로 해당 유저와의 1:1 채팅방을 생성
강사, 수강생 관계 없이 유저 단위로 채팅방 생성

### 테스트
기존 테스트 코드 로직 일부 수정

- [x] 테스트 코드
- [x] API 테스트 